### PR TITLE
Docker Clean-up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+README.md
+LICENSE.md
+Dockerfile
+Containerfile
+.rubocop,yml
+rubocop_todo.ymp
+.gitignore
+.dockerignore
+/.github

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ruby-26
-LABEL maintainer="ops@kennasecurity.com"
 USER root
 
 RUN REPO_LIST="ubi-8-baseos,ubi-8-appstream,ubi-8-codeready-builder"

--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ruby-26
 USER root
 
-RUN REPO_LIST="ubi-8-baseos,ubi-8-appstream,ubi-8-codeready-builder"
-RUN yum update -y
-RUN yum install python3 ruby ruby-devel ruby-irb ruby-libs rubygems rubygems-devel rubygem-bundler -y
-RUN yum -y clean all
+# RUN REPO_LIST="ubi-8-baseos,ubi-8-appstream,ubi-8-codeready-builder"
+# RUN yum update -y
+# RUN yum install ruby ruby-devel ruby-irb ruby-libs rubygems rubygems-devel rubygem-bundler -y
+# RUN yum -y clean all
 
 # Removing NodeJS from base image since it isnt needed. (JG 10/25/2020)
 RUN yum remove -y nodejs 
@@ -26,7 +26,7 @@ ADD . "/opt/app/toolkit/"
 
 # Run Bundle Install
 WORKDIR "/opt/app/toolkit/"
-RUN bundle install
+RUN bundle install --without development test
 
 # Set Entrypoint
 ENTRYPOINT ["./scripts/entrypoint.sh"]


### PR DESCRIPTION
These changes include adding a [dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) file to control what we copy to the container in a better manner. 

Only installing production gems in the container using: `RUN bundle install --without development test`

Not installing `Python3` since there is no python code in the repo.  These changes slims the image down 154MB. 

<img width="733" alt="Screen Shot 2020-12-15 at 1 01 27 PM" src="https://user-images.githubusercontent.com/8428124/102260586-4535a880-3ed6-11eb-9fe4-9aab9f9751b3.png">

