### PR TITLE
Temporarily Remove Solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ group :development, :test do
   gem "rubocop-github"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
-  gem "solargraph"
+  # gem "solargraph" require: false
 end


### PR DESCRIPTION
Temporarily remove Solargraph which is used for VSCode dev that has an unfixed CVE. 