### PR TITLE
A few small optimizations to kdi_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ source "https://rubygems.org"
 gem "aws-sdk-guardduty"
 gem "aws-sdk-inspector"
 gem "json"
+gem "json-write-stream"
 gem "rest-client"
 gem "tty-pager"
-gem "json-write-stream"
 
 group :development, :test do
   gem "pry"

--- a/lib/kdi/kdi_helpers.rb
+++ b/lib/kdi/kdi_helpers.rb
@@ -55,9 +55,9 @@ module Kenna
 
         # if we already have it, skip ... do this by selecting based on our dedupe field
         # and making sure we don't already have it
-
+        uniq_asset_hash = uniq(asset_hash)
         if dup_check
-          return nil if @assets.lazy.select { |a| uniq(a) == uniq(asset_hash) }.any?
+          return nil if @assets.lazy.select { |a| uniq(a) == uniq_asset_hash }.any?
         end
 
         # create default values
@@ -94,11 +94,14 @@ module Kenna
       def create_kdi_asset_vuln(asset_hash, vuln_hash, match_key = nil)
         kdi_initialize unless @assets
 
+        uniq_asset_hash = uniq(asset_hash)
+        asset_hash_key = asset_hash.fetch(match_key)
+
         # check to make sure it doesnt exist
         a = if match_key.nil?
-              @assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+              @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
             else
-              @assets.lazy.find { |asset| asset[match_key] == asset_hash.fetch(match_key) }
+              @assets.lazy.find { |asset| asset[match_key] == asset_hash_key }
             end
 
         # SAnity check to make sure we are pushing data into the correct asset
@@ -106,9 +109,9 @@ module Kenna
           puts "Unable to find asset #{asset_hash}, creating a new one... "
           create_kdi_asset asset_hash
           a = if match_key.nil?
-                @assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+                @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
               else
-                @assets.lazy.find { |asset| asset[match_key] == asset_hash.fetch(match_key) }
+                @assets.lazy.find { |asset| asset[match_key] == asset_hash_key }
               end
         end
 
@@ -131,18 +134,21 @@ module Kenna
       def create_kdi_asset_finding(asset_hash, finding_hash, match_key = nil)
         kdi_initialize unless @assets
 
+        uniq_asset_hash = uniq(asset_hash)
+        asset_hash_key = asset_hash.fetch(match_key)
+
         # check to make sure it doesnt exist
         a = if match_key.nil?
-              @assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+              @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
             else
-              @assets.lazy.find { |asset| asset[match_key] == asset_hash.fetch(match_key) }
+              @assets.lazy.find { |asset| asset[match_key] == asset_hash_key }
             end
 
         # SAnity check to make sure we are pushing data into the correct asset
         unless a # && asset[:vulns].select{|v| v[:scanner_identifier] == args[:scanner_identifier] }.empty?
           puts "Unable to find asset #{asset_hash}, creating a new one... "
           create_kdi_asset asset_hash
-          a = @assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+          a = @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
         end
 
         # Default values & type conversions... just make it work
@@ -159,19 +165,21 @@ module Kenna
       def create_paged_kdi_asset_vuln(asset_hash, vuln_hash, match_key = nil)
         kdi_initialize unless @paged_assets
 
-        # check to make sure it doesnt exists
+        uniq_asset_hash = uniq(asset_hash)
+        asset_hash_key = asset_hash.fetch(match_key)
 
+        # check to make sure it doesnt exists
         a = if match_key.nil?
-              @paged_assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+              @paged_assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
             else
-              @paged_assets.lazy.find { |asset| asset[match_key] == asset_hash.fetch(match_key) }
+              @paged_assets.lazy.find { |asset| asset[match_key] == asset_hash_key }
             end
 
         unless a
           a = if match_key.nil?
-                @assets.lazy.find { |asset| uniq(asset) == uniq(asset_hash) }
+                @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
               else
-                @assets.lazy.find { |asset| asset[match_key] == asset_hash.fetch(match_key) }
+                @assets.lazy.find { |asset| asset[match_key] == asset_hash_key }
               end
           if a
             @paged_assets << a

--- a/lib/kdi/kdi_helpers.rb
+++ b/lib/kdi/kdi_helpers.rb
@@ -86,7 +86,7 @@ module Kenna
         # SAnity check to make sure we are pushing data into the correct asset
         unless a # && asset[:vulns].select{|v| v[:scanner_identifier] == args[:scanner_identifier] }.empty?
           puts "Unable to find asset #{asset_hash}, creating a new one... "
-          create_kdi_asset(asset_hash)
+          create_kdi_asset(asset_hash, false)
           a = if match_key.nil?
                 @assets.lazy.find { |asset| uniq(asset) == uniq_asset_hash }
               else

--- a/lib/kdi/kdi_helpers.rb
+++ b/lib/kdi/kdi_helpers.rb
@@ -94,7 +94,7 @@ module Kenna
               end
         end
 
-        return a
+        a
       end
 
       # create an instance of a vulnerability in our


### PR DESCRIPTION
Based on some feedback in #dev_internal [here](https://kennasecurity.slack.com/archives/C012YTRLQNQ/p1610395067112100?thread_ts=1610393051.108900&cid=C012YTRLQNQ) I pulled a few operations out of the `@assets.lazy.find{}` loop, so that they are done only once, not once for each member of `@assets`.

I also consolidated some duplicated code into a small method.

Full disclosure: I did not formally measure the performance improvement here, nor did I retest the functionality.