### PR TITLE
make bundle install everything from dev/test as well and add pry-byeb…

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ ADD . "/opt/app/toolkit/"
 
 # Run Bundle Install
 WORKDIR "/opt/app/toolkit/"
-RUN bundle install --without development test
+RUN bundle install
 
 # Set Entrypoint
 ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.6
 USER root
 
-# Update the bas image.
+# Update the base image.
 RUN apt-get update -y && apt-get upgrade -y 
 
 # Copy Files To Container.

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "httparty"
 
 group :development, :test do
   gem "pry"
-	gem "pry-byebug"
+  gem "pry-byebug"
   gem "rspec"
   gem "rubocop", "~> 1.6.1", require: false
   gem "rubocop-github"

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "httparty"
 
 group :development, :test do
   gem "pry"
+	gem "pry-byebug"
   gem "rspec"
   gem "rubocop", "~> 1.6.1", require: false
   gem "rubocop-github"


### PR DESCRIPTION
## Summary:
More debugging support! This PR will add `pry-byebug` support to the toolkit so when developing locally in a container you can use `next`, `step`, `continue` functionality that this gem brings when you add a `binding.pry` to a file and trigger the breakpoint. Please see the screenshot below for an example on how you would use this: 

### Example: 
In this example, I have added the following snippet of code to the [example task](https://github.com/KennaSecurity/toolkit/blob/master/tasks/utilities/example/example.rb). I will use this task to showcase how we can attach a pry debugger and utilize the `next` functionality from byebug. 

**To attach a pry debugger to a piece of code and trigger it:**
1. Add the following to the example task in the `run` method: `require 'pry'; binding.pry` 
2. Build the toolkit locally using the Dockerfile: `docker build . -t toolkit:latest`
3. Run the example task in the container: `docker run -it --rm -t toolkit:latest task=example`
![pry_toolkit_debugger](https://user-images.githubusercontent.com/37343501/113452649-0dda0180-93ca-11eb-95ec-2af6564f2500.png)
 You should now be inside of the binding.pry that you set in the example task. To check if you can use commands like `next` that come loaded in from the `Pry::ByeBug` gem you can use the `Pry.commands` command on the console. You should see results like the below screenshot: 
![pry_byebug](https://user-images.githubusercontent.com/37343501/113452841-7cb75a80-93ca-11eb-9ed7-13ab8b5412e2.png)
This same process can be applied to any piece of code that you are actively developing on. When you run the code with the `docker run` commands it should trigger the breakpoint and you can examine the state of the program to debug any issues you may come across :)