### PR TITLE
Omit CWE when CVE exists

### DIFF
--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -275,7 +275,10 @@ module Kenna
                 "description" => description
               }
 
+              # Clear out SRCCLR numbers from CVE list
               vuln_def["cve_identifiers"] = nil unless cve.include? "CVE"
+              # Clear CWE if CVE exists. CVE takes precedence
+              vuln_def["cwe_identifiers"] = nil unless cve.nil?
 
               vuln_def.compact!
 

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -286,7 +286,10 @@ module Kenna
                 "description" => description
               }
 
+              # Clear out SRCCLR numbers from CVE list
               vuln_def["cve_identifiers"] = nil unless cve.include? "CVE"
+              # Clear CWE if CVE exists. CVE takes precedence
+              vuln_def["cwe_identifiers"] = nil unless cve.nil?
 
               vuln_def.compact!
 


### PR DESCRIPTION
Omitting CWE when CVE exists. Backend only takes one.