### PR TITLE
Veracode av updates

### DIFF
--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -45,6 +45,7 @@ module Kenna
               tag_list = []
               application["profile"]["tags"]&.split(",")&.each { |t| tag_list.push(t) } # if application["profile"]["tags"]
               tag_list.push("veracode_bu: #{application['profile']['business_unit']['name']}") if application["profile"]["business_unit"]["name"]
+              tag_list.push("veracode_bc: #{application['profile']['business_criticality']}") if application["profile"]["business_criticality"]
               # tag_list = application["profile"]["tags"].split(",") if application["profile"]["tags"]
               app_list << { "guid" => application.fetch("guid"), "name" => application["profile"]["name"], "tags" => tag_list }
             end
@@ -119,9 +120,9 @@ module Kenna
               ext_id = nil
               case finding["scan_type"]
               when "STATIC"
-                # file = finding["finding_details"]["file_name"]
+                file = finding["finding_details"]["file_name"]
                 # file = "#{finding['finding_details']['file_path']}:#{finding['finding_details']['file_line_number']}"
-                file = finding["finding_details"]["file_path"]
+                # file = finding["finding_details"]["file_path"]
                 ext_id = "[#{app_name}] - #{file}"
               when "DYNAMIC"
                 url = finding["finding_details"]["url"]
@@ -231,9 +232,9 @@ module Kenna
             return if findings.nil?
 
             findings.lazy.each do |finding|
-              # file = finding["finding_details"]["component_filename"]
-              file = finding["finding_details"]["component_path"].first.fetch("path")
-              ext_id = "[#{app_name}] - #{finding['finding_details']['component_path'].first.fetch('path')}"
+              file = finding["finding_details"]["component_filename"]
+              # file = finding["finding_details"]["component_path"].first.fetch("path")
+              ext_id = "[#{app_name}] - #{file}"
 
               # Pull Status from finding["finding_status"]["status"]
               # Per docs this shoule be "OPEN" or "CLOSED"

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -257,7 +257,7 @@ module Kenna
               cwe = finding["finding_details"]["cwe"].fetch("id") if finding["finding_details"]["cwe"]
               cwe = "CWE-#{cwe}" if finding["finding_details"]["cwe"]
               cve = finding["finding_details"]["cve"].fetch("name").strip if finding["finding_details"]["cve"]
-              cve_sol = finding["finding_details"]["cve"]["href"] if finding["finding_details"]["cve"]["href"]
+              cve_solution = finding["finding_details"]["cve"]["href"] if finding["finding_details"]["cve"]["href"]
               found_on = finding["finding_status"].fetch("first_found_date")
               last_seen = finding["finding_status"].fetch("last_seen_date")
               description = finding.fetch("description") if finding["description"]
@@ -308,7 +308,7 @@ module Kenna
                 "cve_identifiers" => cve,
                 "name" => cve,
                 "description" => description,
-                "solution" => cve_sol
+                "solution" => cve_solution
               }
 
               # Clear out SRCCLR numbers from CVE list

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -257,6 +257,7 @@ module Kenna
               cwe = finding["finding_details"]["cwe"].fetch("id") if finding["finding_details"]["cwe"]
               cwe = "CWE-#{cwe}" if finding["finding_details"]["cwe"]
               cve = finding["finding_details"]["cve"].fetch("name").strip if finding["finding_details"]["cve"]
+              cve_sol = finding["finding_details"]["cve"]["href"] if finding["finding_details"]["cve"]["href"]
               found_on = finding["finding_status"].fetch("first_found_date")
               last_seen = finding["finding_status"].fetch("last_seen_date")
               description = finding.fetch("description") if finding["description"]
@@ -306,7 +307,8 @@ module Kenna
                 "cwe_identifiers" => cwe,
                 "cve_identifiers" => cve,
                 "name" => cve,
-                "description" => description
+                "description" => description,
+                "solution" => cve_sol
               }
 
               # Clear out SRCCLR numbers from CVE list


### PR DESCRIPTION
1. Revert filename_locator back to filename rather than filepath.  Filepath contained build numbers which caused new a new asset to be created each build.
2. Add veracode_bc: tag for Business Criticality
3. Add HREF value as solution for CVE and SRCCLR findings.