### PR TITLE
Build Lacework into the toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These are the current tasks available:
 - riskiq: This task connects to the RiskIQ API and pulls results into the Kenna Platform.
 - security_scorecard: This task connects to the Security Scorecard API and pulls results into the Kenna Platform.
 - snyk: Pulls assets and vulnerabilities from Snyk
+- lacework: Pulls assets and vulnerabilities from Lacework
 - upload_file: This task uploads a file to a specified connector
 - user_role_sync: This task creates users and assigns them to roles via the API
 

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/lacework_helper"
 
 module Kenna
@@ -73,22 +75,19 @@ module Kenna
         puts "Generating Temporary Lacework API Token"
         temp_api_token = generate_temporary_lacework_api_token(lacework_account, lacework_api_key, lacework_api_secret)
 
-
         # Pull assets and vulns from Lacework
         puts "Pulling asset and vulnerability data from Lacework API"
 
         environment_cves = lacework_list_cves(lacework_account, temp_api_token)
 
         vulns_by_host = environment_cves["data"]
-                          .map{|cve| cve["cve_id"]}
-                          .flat_map{|cve_id| lacework_list_hosts(lacework_account, cve_id, temp_api_token) }
-                          .each_with_object(Hash.new{|h, k| h[k] = [] }) do |host, hash|
-
-                            key = [host["host"]["tags"]["Hostname"],
-                                   host["host"]["machine_id"],
-                                   host["host"]["tags"]["InternalIp"]
-                                  ]
-                            hash[key] += vulns_for(host)
+                        .map { |cve| cve["cve_id"] }
+                        .flat_map { |cve_id| lacework_list_hosts(lacework_account, cve_id, temp_api_token) }
+                        .each_with_object(Hash.new { |h, k| h[k] = [] }) do |host, hash|
+          key = [host["host"]["tags"]["Hostname"],
+                 host["host"]["machine_id"],
+                 host["host"]["tags"]["InternalIp"]]
+          hash[key] += vulns_for(host)
         end
 
         # Format KDI hash
@@ -99,7 +98,7 @@ module Kenna
             "hostname": host[0],
             "external_id": host[1],
             "ip_address": host[2],
-            "tags":[
+            "tags": [
               "lacework_kdi"
             ]
           }
@@ -124,7 +123,6 @@ module Kenna
             create_kdi_vuln_def(vuln_def_hash)
           end
         end
-
 
         # Write KDI format
         output_dir = "#{$basedir}/#{@options[:output_directory]}"

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -1,0 +1,142 @@
+require_relative "lib/lacework_helper"
+
+module Kenna
+  module Toolkit
+    class Lacework < Kenna::Toolkit::BaseTask
+      include Kenna::Toolkit::LaceworkHelper
+
+      def self.metadata
+        {
+          id: "lacework",
+          name: "Lacework",
+          description: "This task pulls host results from the Lacework API and translates them into KDI",
+          options: [
+            {
+              name: "lacework_account",
+              type: "string",
+              required: true,
+              default: nil,
+              description: "This is the Lacework account name."
+            }, {
+              name: "lacework_api_key",
+              type: "api_key",
+              required: true,
+              default: nil,
+              description: "This is the Lacework api access key used to query the API."
+            }, {
+              name: "lacework_api_secret",
+              type: "string",
+              required: true,
+              default: nil,
+              description: "This is the Lacework api secret used to query the API."
+            }, {
+              name: "kenna_api_key",
+              type: "api_key",
+              required: false,
+              default: nil,
+              description: "Kenna API Key"
+            }, {
+              name: "kenna_api_host",
+              type: "hostname",
+              required: false,
+              default: "api.kennasecurity.com",
+              description: "Kenna API Hostname"
+            }, {
+              name: "kenna_connector_id",
+              type: "integer",
+              required: false,
+              default: nil,
+              description: "If set, we'll try to upload to this connector"
+            }, {
+              name: "output_directory",
+              type: "filename",
+              required: false,
+              default: "output",
+              description: "If set, will write a file upon completion. Path is relative to #{$basedir}"
+            }
+          ]
+        }
+      end
+
+      def run(opts)
+        super
+
+        lacework_account = @options[:lacework_account]
+        lacework_api_key = @options[:lacework_api_key]
+        lacework_api_secret = @options[:lacework_api_secret]
+
+        @kenna_api_key = @options[:kenna_api_key]
+        @kenna_connector_id = @options[:kenna_connector_id]
+        @kenna_api_host = @options[:kenna_api_host]
+
+        # Generate Temporary Lacework API Token
+        puts "Generating Temporary Lacework API Token"
+        temp_api_token = generate_temporary_lacework_api_token(lacework_account, lacework_api_key, lacework_api_secret)
+
+
+        # Pull assets and vulns from Lacework
+        puts "Pulling asset and vulnerability data from Lacework API"
+
+        environment_cves = lacework_list_cves(lacework_account, temp_api_token)
+
+        vulns_by_host = environment_cves["data"]
+                          .map{|cve| cve["cve_id"]}
+                          .flat_map{|cve_id| lacework_list_hosts(lacework_account, cve_id, temp_api_token) }
+                          .each_with_object(Hash.new{|h, k| h[k] = [] }) do |host, hash|
+
+                            key = [host["host"]["tags"]["Hostname"],
+                                   host["host"]["machine_id"],
+                                   host["host"]["tags"]["InternalIp"]
+                                  ]
+                            hash[key] += vulns_for(host)
+        end
+
+        # Format KDI hash
+        puts "Formatting Lacework data for Kenna KDI"
+
+        vulns_by_host.each do |host, vulns|
+          asset_hash = {
+            "hostname": host[0],
+            "external_id": host[1],
+            "ip_address": host[2],
+            "tags":[
+              "lacework_kdi"
+            ]
+          }
+
+          vulns.each do |vuln|
+            vuln_hash = {
+              "scanner_identifier" => vuln[:scanner_identifier],
+              "scanner_type" => vuln[:scanner_type],
+              "scanner_score" => vuln[:scanner_score],
+              "last_seen_at" => vuln[:last_seen_at],
+              "status" => vuln[:status],
+              "vuln_def_name" => vuln[:vuln_def_name]
+            }
+
+            vuln_def_hash = {
+              "scanner_identifier" => vuln[:scanner_identifier],
+              "scanner_type" => vuln[:scanner_type],
+              "name" => vuln[:vuln_def_name]
+            }
+
+            create_kdi_asset_vuln(asset_hash, vuln_hash)
+            create_kdi_vuln_def(vuln_def_hash)
+          end
+        end
+
+
+        # Write KDI format
+        output_dir = "#{$basedir}/#{@options[:output_directory]}"
+        filename = "lacework_kdi.json"
+
+        puts "Output is available at: #{output_dir}/#{filename}"
+
+        # Upload KDI file to Kenna
+        puts "Uploading KDI file to Kenna and running KDI connector"
+        kdi_upload output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, 3, 2
+        kdi_connector_kickoff @kenna_connector_id, @kenna_api_host, @kenna_api_key if @kenna_connector_id && @kenna_api_host && @kenna_api_key
+      end
+    end
+  end
+end

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -1,5 +1,7 @@
-require 'net/http'
-require 'uri'
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
 
 module Kenna
   module Toolkit
@@ -11,14 +13,14 @@ module Kenna
 
         request = Net::HTTP::Post.new(uri)
         request.content_type = "application/json"
-        request["X-Lw-Uaks"] = "#{api_secret}"
+        request["X-Lw-Uaks"] = api_secret.to_s
         request.body = JSON.dump({
-          "keyId" => "#{api_key}",
-          "expiryTime" => 9999
-        })
+                                   "keyId" => api_key.to_s,
+                                   "expiryTime" => 9999
+                                 })
 
         req_options = {
-          use_ssl: uri.scheme == "https",
+          use_ssl: uri.scheme == "https"
         }
 
         response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
@@ -43,10 +45,10 @@ module Kenna
         loop do
           attempts += 1
           response = `#{cmd}`
-          status = $?
+          status = $CHILD_STATUS
           break response if status.success?
 
-          STDERR.puts "#{cmd} failed (attempt #{attempts})."
+          warn "#{cmd} failed (attempt #{attempts})."
           raise StandardError, "Retries exhausted for #{cmd}" if attempts == MAX_ATTEMPTS
         end
       end
@@ -55,11 +57,11 @@ module Kenna
         host["packages"].map do |package|
           {
             "scanner_identifier": package["cve_link"].match(/CVE(.*)$/)[0],
-           "scanner_type": "Lacework",
-           "scanner_score": package["cvss_score"].to_i,
-           "last_seen_at": Time.now.utc,
-           "status": package["status"] == "Active" ? "open" : "closed",
-           "vuln_def_name": package["cve_link"].match(/CVE(.*)$/)[0]
+            "scanner_type": "Lacework",
+            "scanner_score": package["cvss_score"].to_i,
+            "last_seen_at": Time.now.utc,
+            "status": package["status"] == "Active" ? "open" : "closed",
+            "vuln_def_name": package["cve_link"].match(/CVE(.*)$/)[0]
           }
         end
       end

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -1,0 +1,68 @@
+require 'net/http'
+require 'uri'
+
+module Kenna
+  module Toolkit
+    module LaceworkHelper
+      MAX_ATTEMPTS = 3
+
+      def generate_temporary_lacework_api_token(account, api_key, api_secret)
+        uri = URI.parse("https://#{account}.lacework.net/api/v1/access/tokens")
+
+        request = Net::HTTP::Post.new(uri)
+        request.content_type = "application/json"
+        request["X-Lw-Uaks"] = "#{api_secret}"
+        request.body = JSON.dump({
+          "keyId" => "#{api_key}",
+          "expiryTime" => 9999
+        })
+
+        req_options = {
+          use_ssl: uri.scheme == "https",
+        }
+
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+          http.request(request)
+        end
+
+        JSON.parse(response.body)["data"].last["token"]
+      end
+
+      def lacework_list_hosts(account, cve_id, temp_api_token)
+        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host/cveId/#{cve_id}' -H 'Authorization: Bearer #{temp_api_token}'")
+        JSON.parse(raw)
+      end
+
+      def lacework_list_cves(account, temp_api_token)
+        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host' -H 'Authorization: Bearer #{temp_api_token}'")
+        JSON.parse(raw)
+      end
+
+      def call(cmd)
+        attempts = 0
+        loop do
+          attempts += 1
+          response = `#{cmd}`
+          status = $?
+          break response if status.success?
+
+          STDERR.puts "#{cmd} failed (attempt #{attempts})."
+          raise StandardError, "Retries exhausted for #{cmd}" if attempts == MAX_ATTEMPTS
+        end
+      end
+
+      def vulns_for(host)
+        host["packages"].map do |package|
+          {
+            "scanner_identifier": package["cve_link"].match(/CVE(.*)$/)[0],
+           "scanner_type": "Lacework",
+           "scanner_score": package["cvss_score"].to_i,
+           "last_seen_at": Time.now.utc,
+           "status": package["status"] == "Active" ? "open" : "closed",
+           "vuln_def_name": package["cve_link"].match(/CVE(.*)$/)[0]
+          }
+        end
+      end
+    end
+  end
+end

--- a/tasks/connectors/lacework/readme.md
+++ b/tasks/connectors/lacework/readme.md
@@ -1,0 +1,47 @@
+# Lacework Toolkit Task to Kenna.VM
+
+## This Task will use the Lacework API to
+
+- Get a list of CVEs currently present in the user's Lacework account
+- Get a list of Hosts in the user's Lacework account associated with each CVE
+- Output a json file in the Kenna Data Importer (KDI) format.
+- Post the file to Kenna if API Key and Connector ID are provided
+
+## Things you will need
+
+- Lacework API Key (Required)
+- Lacework API Secret (Required)
+- Lacework Account Name (Required)
+- Kenna API Key (Optional but needed for automatic upload to Kenna)
+- Kenna Connector ID (Optional but needed for automatic upload to Kenna)
+
+Running the Task:
+
+- Retrieve the Lacework API Key and Secret from the Lacework UI.
+  - From the Settings menu, create a new API key if none created
+  - Download the key file to retrieve the key itself, plus secret
+- Retrieve the Kenna API Key from the Kenna UI.
+  - From the Gear icon (Upper right corner) select API Keys
+  - Copy the key using the copy button to the left of the obscured key
+- Retrieve the Kenna Connector ID
+  - If not already created, select the Add Connector button to create a connector of type Kenna Data Importer. Be sure to rename the connector using 'Snyk' in the name.
+  - Click on the name of the connector and from the resulting page, copy the Connector ID.
+
+Run the Lacework task following the guidelines on the main [toolkit help page](https://github.com/KennaPublicSamples/toolkit#calling-a-specific-task) adding options as necessary
+
+## Options
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| lacework_api_token |api_key | true | Lacework API Token |
+| lacework_api_secret | string | true | Lacework API Secret |
+| lacework_account |string | true | Lacework Account Name |
+| kenna_api_key | api_key | false | Kenna API Key |
+| kenna_api_host | hostname | false | Kenna API Hostname |
+| kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
+| output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
+
+
+## Example Command Line:
+
+    toolkit:latest task=lacework lacework_api_token=xxx lacework_api_secret=xxx lacework_account=xxx kenna_connector_id=156xxx kenna_api_key:xxx

--- a/tasks/connectors/lacework/readme.md
+++ b/tasks/connectors/lacework/readme.md
@@ -24,7 +24,7 @@ Running the Task:
   - From the Gear icon (Upper right corner) select API Keys
   - Copy the key using the copy button to the left of the obscured key
 - Retrieve the Kenna Connector ID
-  - If not already created, select the Add Connector button to create a connector of type Kenna Data Importer. Be sure to rename the connector using 'Snyk' in the name.
+  - If not already created, select the Add Connector button to create a connector of type Kenna Data Importer. Be sure to rename the connector using 'Lacework' in the name.
   - Click on the name of the connector and from the resulting page, copy the Connector ID.
 
 Run the Lacework task following the guidelines on the main [toolkit help page](https://github.com/KennaPublicSamples/toolkit#calling-a-specific-task) adding options as necessary


### PR DESCRIPTION
This PR adds a connector to the toolkit for retrieving host and vulnerability data from the lacework api.  It pipes that data into Kenna using the KDI and Kenna API.  This is my first foray into the toolkit, so feedback welcome!