### PR TITLE
Lacework toolkit: code format updates, only pull back Active CVEs from Lacework

### DIFF
--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -84,10 +84,10 @@ module Kenna
         affected_hosts = cve_list.flat_map { |cve_id| lacework_list_hosts(lacework_account, cve_id, temp_api_token)["data"] }
 
         vulns_by_host = affected_hosts.each_with_object(Hash.new { |h, k| h[k] = [] }) do |host, hash|
-           key = [host["host"]["tags"]["Hostname"],
-                  host["host"]["machine_id"],
-                  host["host"]["tags"]["InternalIp"]]
-           hash[key] += vulns_for(host)
+          key = [host["host"]["tags"]["Hostname"],
+                 host["host"]["machine_id"],
+                 host["host"]["tags"]["InternalIp"]]
+          hash[key] += vulns_for(host)
         end
 
         # Format KDI hash

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -31,7 +31,7 @@ module Kenna
       end
 
       def lacework_list_hosts(account, cve_id, temp_api_token)
-        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host/cveId/#{cve_id}' -H 'Authorization: Bearer #{temp_api_token}'")
+        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host/cveId/#{cve_id}?status=Active' -H 'Authorization: Bearer #{temp_api_token}'")
         JSON.parse(raw)
       end
 


### PR DESCRIPTION
Fixes a couple formatting issues:

- there were duplicate hash keys being created as a result of stringified keys vs symbols.  This PR addresses that by converting all keys to strings
- breaks up the multistep vulns_by_host loop for better readability
- only pull back Active vulnerabilities and let Kenna handle vulnerability autoclose