### PR TITLE
required changes

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -35,6 +35,15 @@ module Kenna
           puts "Exception! #{e}"
         rescue RestClient::ServerBrokeConnection => e
           puts "Exception! #{e}"
+        rescue RestClient::ExceptionWithResponse => e
+          puts "Exception! #{e}"
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
+            retry
+          end
         rescue RestClient::NotFound => e
           puts "Exception! #{e}"
         rescue RestClient::Exception => e
@@ -44,6 +53,15 @@ module Kenna
             retries += 1
             sleep(15)
             puts "Retrying!"
+            retry
+          end
+        rescue Errno::ECONNREFUSED => e
+          puts "Exception! #{e}"
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
             retry
           end
         end
@@ -80,9 +98,27 @@ module Kenna
           end
         rescue RestClient::ServerBrokeConnection => e
           puts "Exception! #{e}"
+        rescue RestClient::ExceptionWithResponse => e
+          puts "Exception! #{e}"
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
+            retry
+          end
         rescue RestClient::NotFound => e
           puts "Exception! #{e}"
         rescue RestClient::Exception => e
+          puts "Exception! #{e}"
+          retries ||= 0
+          if retries < max_retries
+            retries += 1
+            puts "Retrying!"
+            sleep(15)
+            retry
+          end
+        rescue Errno::ECONNREFUSED => e
           puts "Exception! #{e}"
           retries ||= 0
           if retries < max_retries

--- a/toolkit.rb
+++ b/toolkit.rb
@@ -10,8 +10,9 @@ args_array = ARGV.map { |arg| arg.split(":") }.flatten
 # Then split up this into a hash
 args = {}
 args_array.each do |arg|
-  arg_name  = arg.split("=").first.to_sym
-  arg_value = arg.split("=").last
+  arg_name, arg_value = arg.split(/(=.*)/)
+  arg_name = arg_name.to_sym
+  arg_value = arg_value.delete_prefix("=")
 
   # handle a request for just "help" as a special case
   # if arg_name = "help"


### PR DESCRIPTION
Changes to toolkit.rb are needed because even with quotes, the current code will drop equal signs at the end of a string. In the sample case, an API key had == at the end and those 2 characters were dropped even with quotes around the string. Code has been tested with param separated by both space and colon. 