### PR TITLE
Update Container Base Image From EOL Version. 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.6
 USER root
 
 # Update the base image.


### PR DESCRIPTION
The ruby base image we are using has went EOL.  We were running Ruby 2.6.6 on Debian 10.09, this change updates the image to Ruby 2.6.7 on Debian 10.10.   
