### PR TITLE
Add Cobalt.io Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ These are the current tasks available:
 - aws_guardduty: This task pulls results from AWS GuardDuty API and translates them into KDI JSON
 - aws_inspector: This task pulls results from AWS inspector API and translates them into KDI JSON
 - bitsight: This task connects to the Bitsight API and pulls results into the Kenna Platform.
+- cobaltio: This task connects to the Cobalt.io API and pulls findings into the Kenna Platform.
 - contrast: This task connects to the Contrast Security API and pulls results into the Kenna Platform.
 - csv2kdi: This task converts a csv formatted file to the Kenna JSON & optionally pulls results into Kenna
 - edgescan: Pulls assets and vulnerabilitiies from Edgescan

--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require_relative "lib/cobaltio_helper"
+
+module Kenna
+  module Toolkit
+    class Cobaltio < Kenna::Toolkit::BaseTask
+      include Kenna::Toolkit::CobaltioHelper
+
+      SCANNER = "Cobalt.io"
+
+      def self.metadata
+        {
+          id: "cobaltio",
+          name: "Cobalt.io",
+          description: "Pulls findings from Cobalt.io",
+          options: [
+            { name: "cobalt_api_token",
+              type: "api_key",
+              required: true,
+              default: nil,
+              description: "Cobalt.io API token" },
+            { name: "cobalt_org_token",
+              type: "api_key",
+              required: true,
+              default: nil,
+              description: "Cobalt.io org token" },
+            { name: "retrieve_from",
+              type: "date",
+              required: false,
+              default: 90,
+              description: "default will be 90 days before today" },
+            { name: "projectName_strip_colon",
+              type: "boolean",
+              required: false,
+              default: false,
+              description: "strip colon and following data from Project Name - used as application identifier" },
+            { name: "packageManager_strip_colon",
+              type: "boolean",
+              required: false,
+              default: false,
+              description: "strip colon and following data from packageManager - used in asset file locator" },
+            { name: "package_strip_colon",
+              type: "boolean",
+              required: false,
+              default: false,
+              description: "strip colon and following data from package - used in asset file locator" },
+            { name: "kenna_connector_id",
+              type: "integer",
+              required: false,
+              default: nil,
+              description: "If set, we'll try to upload to this connector" },
+            { name: "kenna_api_key",
+              type: "api_key",
+              required: false,
+              default: nil,
+              description: "Kenna API Key" },
+            { name: "kenna_api_host",
+              type: "hostname",
+              required: false,
+              default: "api.kennasecurity.com",
+              description: "Kenna API Hostname" },
+            { name: "output_directory",
+              type: "filename",
+              required: false,
+              default: "output/cobaltio",
+              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" }
+
+          ]
+        }
+      end
+
+      def run(opts)
+        super # opts -> @options
+
+        cobalt_api_token = @options[:cobalt_api_token]
+        cobalt_org_token = @options[:cobalt_org_token]
+
+        @kenna_api_host = @options[:kenna_api_host]
+        @kenna_api_key = @options[:kenna_api_key]
+        @kenna_connector_id = @options[:kenna_connector_id]
+
+        # output_directory = @options[:output_directory]
+
+        projectName_strip_colon = @options[:projectName_strip_colon]
+        packageManager_strip_colon = @options[:packageManager_strip_colon]
+        package_strip_colon = @options[:package_strip_colon]
+        to_date = Date.today.strftime("%Y-%m-%d")
+        retrieve_from = @options[:retrieve_from]
+        from_date = (Date.today - retrieve_from.to_i).strftime("%Y-%m-%d")
+
+        findings_json = cobalt_get_findings(cobalt_api_token, cobalt_org_token)
+        print_debug "findings json = #{findings_json}"
+
+        severity_map = { "high" => 7, "medium" => 5, "low" => 3 } # converter
+        state_map = { "need_fix" => "new", "wont_fix" => "risk_accepted", "valid_fix" => "resolved", "check_fix" => "in_progress", "carried_over" => "new" }
+        findings_json.each do |finding_obj|
+          next if cobalt_exclude_finding(finding_obj)
+
+          resource = finding_obj["resource"]
+          links = finding_obj["links"]
+          log = resource["log"]
+
+          asset_id = resource["asset_id"]
+          cobalt_asset = cobalt_get_asset(cobalt_api_token, cobalt_org_token, asset_id)
+          application = cobalt_asset["resource"]["title"] if cobalt_asset
+
+          asset = {
+            "external_id" => asset_id,
+            "application" => application,
+          }
+
+          vuln_def_name = resource["title"]
+          description = resource["description"]
+          solution = resource.fetch("suggested_fix") if resource.key?("suggested_fix")
+
+          vuln_def = {
+            "scanner_type" => SCANNER,
+            "name" => vuln_def_name,
+            "description" => description,
+            "solution" => solution,
+          }
+          vuln_def.compact!
+
+          impact = resource["impact"]
+          likelihood = resource["likelihood"]
+          proof_of_concept = resource.fetch("proof_of_concept") if resource.key?("proof_of_concept")
+          cobalt_state = resource["state"]
+          cobalt_url = links["ui"]["url"]
+
+          additional_fields = {
+            "impact" => impact,
+            "likelihood" => likelihood,
+            "proof_of_concept" => proof_of_concept,
+            "cobalt_state" => cobalt_state,
+            "cobalt_url" => cobalt_url,
+          }
+          additional_fields.compact!
+
+          scanner_identifier = resource["id"]
+          created_at = cobalt_get_created(log)
+          last_seen_at = created_at
+          severity = severity_map.fetch(resource.fetch("severity"))
+          triage_state = state_map.fetch(resource["state"])
+
+          finding = {
+            "scanner_type" => SCANNER,
+            "scanner_identifier" => scanner_identifier,
+            "created_at" => created_at,
+            "last_seen_at" => last_seen_at,
+            "severity" => severity,
+            "vuln_def_name" => vuln_def_name,
+            "triage_state" => triage_state,
+            "additional_fields" => additional_fields,
+          }
+          finding.compact!
+
+          # Create the KDI entries
+          create_kdi_asset_vuln(asset, finding)
+          create_kdi_vuln_def(vuln_def)
+        end
+
+        ### Write KDI format
+        output_dir = "#{$basedir}/#{@options[:output_directory]}"
+        filename = "cobaltio_kdi.json"
+        kdi_upload output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, 3, 2
+        kdi_connector_kickoff @kenna_connector_id, @kenna_api_host, @kenna_api_key if @kenna_connector_id && @kenna_api_host && @kenna_api_key
+      end
+    end
+  end
+end

--- a/tasks/connectors/cobaltio/lib/cobaltio_helper.rb
+++ b/tasks/connectors/cobaltio/lib/cobaltio_helper.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Kenna
+  module Toolkit
+    module CobaltioHelper
+      @@assets = []
+
+      def cobalt_get_assets(api_token, org_token)
+        print "Getting list of assets"
+        cobalt_assets_api = "https://api.cobalt.io/assets"
+        headers = cobalt_get_req_headers(api_token, org_token)
+
+        response = http_get(cobalt_assets_api, headers)
+        return nil unless response
+
+        begin
+          json = JSON.parse(response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process response!"
+        end
+
+        @@assets = json["data"]
+      end
+
+      def cobalt_get_asset(api_token, org_token, asset_id)
+        cobalt_get_assets(api_token, org_token) if @@assets.length == 0
+        @@assets.find { |entry| entry["resource"]["id"] == asset_id }
+      end
+
+      def cobalt_get_findings(api_token, org_token)
+        print "Getting list of findings"
+        cobalt_findings_api = "https://api.cobalt.io/findings"
+        headers = cobalt_get_req_headers(api_token, org_token)
+
+        response = http_get(cobalt_findings_api, headers)
+        return nil unless response
+
+        begin
+          json = JSON.parse(response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process response!"
+        end
+
+        json["data"]
+      end
+
+      def cobalt_get_req_headers(api_token, org_token)
+        headers = { "accept" => "application/vnd.cobalt.v1+json",
+                    "Authorization" => "Bearer #{api_token}",
+                    "X-Org-Token" => org_token }
+      end
+
+      def cobalt_get_created(finding_log)
+        created_entry = finding_log.find { |entry| entry["action"] == "created" }
+        return nil unless created_entry
+        created_entry.fetch("timestamp") if created_entry
+      end
+
+      def cobalt_exclude_finding(finding_obj)
+        state = finding_obj["resource"]["state"]
+        import_states = ["need_fix", "wont_fix", "valid_fix", "check_fix", "carried_over"]
+        not import_states.include? state
+      end
+    end
+  end
+end

--- a/tasks/connectors/cobaltio/readme.md
+++ b/tasks/connectors/cobaltio/readme.md
@@ -1,0 +1,46 @@
+# Cobalt.io Toolkit Task to Kenna.VM
+
+## This Task will use the Cobalt.io API to
+
+- [Get a list of Findings](https://docs.cobalt.io/#findings) for the Org.
+- Output a json file in the Kenna Data Importer (KDI) format.
+- Post the file to Kenna if API Key and Connector ID are provided.
+
+## Things you will need
+
+- Cobalt.io API token & org token (Required)
+- Kenna API Key (Optional but needed for automatic upload to Kenna)
+- Kenna Connector ID (Optional but needed for automatic upload to Kenna)
+
+Running the Task:
+
+- Retrieve the Cobalt.io API Key from the Cobalt.io UI
+  - From Account Dropdown (Upper right corner) select API Token
+  - Click "Generate Token" to generate an API token, copy it and store it somewhere safe
+- Get the Cobalt.io org token from the Cobalt.io API
+  - Make a GET request to `https://api.cobalt.io/orgs` and get the `token` value of the org you want to use
+  - See [the Cobalt.io API docs](https://docs.cobalt.io) for details
+- Retrieve the Kenna API Key from the Kenna UI
+  - From the Gear icon (Upper right corner) select API Keys
+  - Copy the key using the copy button to the left of the obscured key
+- Retrieve the Kenna Connector ID
+  - If not already created, select the Add Connector button to create a connector of type Kenna Data Importer. Be sure to rename the connector using "Cobalt.io" in the name
+  - Click on the name of the connector and from the resulting page, copy the Connector ID
+
+Run the Cobalt.io task following the guidelines on the main [toolkit help page](https://github.com/KennaPublicSamples/toolkit#calling-a-specific-task) adding options as necessary
+
+## Options
+
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| cobalt_api_token | api_key | true | Cobalt.io API token |
+| cobalt_org_token | string | true | Cobalt.io org token |
+| kenna_api_key | api_key | false | Kenna API Key |
+| kenna_api_host | hostname | false | Kenna API Hostname |
+| kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
+| output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
+
+
+## Example Command Line:
+
+    toolkit:latest task=cobaltio cobalt_api_token=xxx cobalt_org_token=xxx kenna_api_key:xxx kenna_connector_id=xxxxxx

--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -12,6 +12,7 @@
 | aws_guardduty | Pre-Release/Beta | Kenna |
 | aws_inspector | Pre-Release/Beta | Kenna |
 | bitsight | Released | Kenna |
+| cobaltio | Beta | Cobalt.io |
 | contrast | Beta | Contrast Security |
 | edgescan | Pre-Release/Beta | edgescan |
 | expanse | Pre-Released/Beta | Kenna |


### PR DESCRIPTION
This adds a connector/task for Cobalt.io (_full disclosure, I'm a software engineer at Cobalt.io_). It works by pulling in findings and asset information from [the Cobalt.io public API](https://docs.cobalt.io). I based the task implementation and corresponding README off of [Snyk's task](https://github.com/KennaSecurity/toolkit/tree/6733d97af1824e4594518911513e3474711b2173/tasks/connectors/snyk).

Some notes on the task that may require additional attention:

- Findings marked as "wont_fix" and "valid_fix" in Cobalt are imported and flagged as "risk_accepted" and "resolved" respectively. Alternatively these could not be imported at all.
- Findings marked as "duplicate", "out_of_scope", or "invalid" in Cobalt are not imported at all.
- It currently imports all findings for all assets in Cobalt.io. I implemented it this way because that's how Snyk's task seems to work. A reasonable alternative would be to import [findings from one asset or one pentest](https://docs.cobalt.io/#get-specific-findings). Note that in that case there will always be only one Kenna Security asset in the imported dataset.

One open question from my side is whether to import findings as _vulns_ or as _findings_. The difference is not quite clear to me, except that when I import findings from Cobalt as _findings_ I cannot find them in the Kenna Dashboard.