### PR TITLE
Obscure "_id" parameters

### DIFF
--- a/tasks/base.rb
+++ b/tasks/base.rb
@@ -94,7 +94,7 @@ module Kenna
 
         # Print out the options so the user knows and logs what we're doing
         @options.each do |k, v|
-          if k =~ /key/ ||  k =~ /token/ || k =~ /secret/ # special case anything that has key in it
+          if k =~ /key/ ||  k =~ /token/ || k =~ /secret/ || k =~ /_id/ # special case anything that has key in it
             print_good "Got option: #{k}: #{v[0]}*******#{v[-3..-1]}" if v
           else
             print_good "Got option: #{k}: #{v}"


### PR DESCRIPTION
Obscure "_id" parameters:

This update will additionally obscure parameters that contain "_id".