### PR TITLE
Add support for findings to Cobalt.io task

### DIFF
--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -25,11 +25,6 @@ module Kenna
               required: true,
               default: nil,
               description: "Cobalt.io org token" },
-            { name: "retrieve_from",
-              type: "date",
-              required: false,
-              default: 90,
-              description: "default will be 90 days before today" },
             { name: "kenna_api_key",
               type: "api_key",
               required: false,
@@ -65,10 +60,6 @@ module Kenna
         @kenna_connector_id = @options[:kenna_connector_id]
 
         # output_directory = @options[:output_directory]
-
-        to_date = Date.today.strftime("%Y-%m-%d")
-        retrieve_from = @options[:retrieve_from]
-        from_date = (Date.today - retrieve_from.to_i).strftime("%Y-%m-%d")
 
         findings_json = cobalt_get_findings(cobalt_api_token, cobalt_org_token)
         print_debug "findings json = #{findings_json}"

--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -40,6 +40,11 @@ module Kenna
               required: false,
               default: "api.kennasecurity.com",
               description: "Kenna API Hostname" },
+            { name: "kenna_connector_id",
+              type: "integer",
+              required: true,
+              default: nil,
+              description: "If set, we'll try to upload to this connector" },
             { name: "output_directory",
               type: "filename",
               required: false,
@@ -132,7 +137,8 @@ module Kenna
           finding.compact!
 
           # Create the KDI entries
-          create_kdi_asset_vuln(asset, finding)
+          #create_kdi_asset_vuln(asset, finding)
+          create_kdi_asset_finding(asset, finding)
           create_kdi_vuln_def(vuln_def)
         end
 

--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -40,6 +40,11 @@ module Kenna
               required: true,
               default: nil,
               description: "If set, we'll try to upload to this connector" },
+            { name: "kenna_appsec_module",
+              type: "boolean",
+              required: false,
+              default: true,
+              description: "Controls whether to use the newer Kenna AppSec module, set to false if you want to use the VM module (and group by CWE)" },
             { name: "output_directory",
               type: "filename",
               required: false,
@@ -58,6 +63,7 @@ module Kenna
         @kenna_api_host = @options[:kenna_api_host]
         @kenna_api_key = @options[:kenna_api_key]
         @kenna_connector_id = @options[:kenna_connector_id]
+        @kenna_appsec_module = @options[:kenna_appsec_module]
 
         # output_directory = @options[:output_directory]
 
@@ -66,6 +72,7 @@ module Kenna
 
         severity_map = { "high" => 7, "medium" => 5, "low" => 3 } # converter
         state_map = { "need_fix" => "new", "wont_fix" => "risk_accepted", "valid_fix" => "resolved", "check_fix" => "in_progress", "carried_over" => "new" }
+        status_map = { "need_fix" => "open", "wont_fix" => "closed", "valid_fix" => "closed", "check_fix" => "open", "carried_over" => "open" }
         findings_json.each do |finding_obj|
           next if cobalt_exclude_finding(finding_obj)
 
@@ -93,44 +100,58 @@ module Kenna
             "solution" => solution,
           }
           vuln_def.compact!
-
-          impact = resource["impact"]
-          likelihood = resource["likelihood"]
-          proof_of_concept = resource.fetch("proof_of_concept") if resource.key?("proof_of_concept")
-          cobalt_state = resource["state"]
-          cobalt_url = links["ui"]["url"]
-
-          additional_fields = {
-            "impact" => impact,
-            "likelihood" => likelihood,
-            "proof_of_concept" => proof_of_concept,
-            "cobalt_state" => cobalt_state,
-            "cobalt_url" => cobalt_url,
-          }
-          additional_fields.compact!
+          create_kdi_vuln_def(vuln_def)
 
           scanner_identifier = resource["id"]
           created_at = cobalt_get_created(log)
           last_seen_at = created_at
           severity = severity_map.fetch(resource.fetch("severity"))
           triage_state = state_map.fetch(resource["state"])
+          vuln_status = status_map.fetch(resource["state"])
 
-          finding = {
-            "scanner_type" => SCANNER,
-            "scanner_identifier" => scanner_identifier,
-            "created_at" => created_at,
-            "last_seen_at" => last_seen_at,
-            "severity" => severity,
-            "vuln_def_name" => vuln_def_name,
-            "triage_state" => triage_state,
-            "additional_fields" => additional_fields,
-          }
-          finding.compact!
+          if @kenna_appsec_module == true
+            impact = resource["impact"]
+            likelihood = resource["likelihood"]
+            proof_of_concept = resource.fetch("proof_of_concept") if resource.key?("proof_of_concept")
+            cobalt_state = resource["state"]
+            cobalt_url = links["ui"]["url"]
 
-          # Create the KDI entries
-          #create_kdi_asset_vuln(asset, finding)
-          create_kdi_asset_finding(asset, finding)
-          create_kdi_vuln_def(vuln_def)
+            additional_fields = {
+              "impact" => impact,
+              "likelihood" => likelihood,
+              "proof_of_concept" => proof_of_concept,
+              "cobalt_state" => cobalt_state,
+              "cobalt_url" => cobalt_url,
+            }
+            additional_fields.compact!
+
+            finding = {
+              "scanner_type" => SCANNER,
+              "scanner_identifier" => scanner_identifier,
+              "created_at" => created_at,
+              "last_seen_at" => last_seen_at,
+              "severity" => severity,
+              "vuln_def_name" => vuln_def_name,
+              "triage_state" => triage_state,
+              "additional_fields" => additional_fields,
+            }
+            finding.compact!
+
+            create_kdi_asset_finding(asset, finding)
+          else
+            vuln = {
+              "scanner_type" => SCANNER,
+              "scanner_identifier" => scanner_identifier,
+              "scanner_score" => severity,
+              "created_at" => created_at,
+              "last_seen_at" => last_seen_at,
+              "status" => vuln_status,
+              "vuln_def_name" => vuln_def_name,
+            }
+            vuln.compact!
+
+            create_kdi_asset_vuln(asset, vuln)
+          end
         end
 
         ### Write KDI format

--- a/tasks/connectors/cobaltio/readme.md
+++ b/tasks/connectors/cobaltio/readme.md
@@ -38,6 +38,7 @@ Run the Cobalt.io task following the guidelines on the main [toolkit help page](
 | kenna_api_key | api_key | false | Kenna API Key |
 | kenna_api_host | hostname | false | Kenna API Hostname |
 | kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
+| kenna_appsec_module | boolean | false | Controls whether to use the newer Kenna AppSec module, set to `false` if you want to use the VM module |
 | output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
 
 


### PR DESCRIPTION
Following up on #201, this add support for importing data from Cobalt.io as _findings_. This time the implementation is based off of [the Contrast task](https://github.com/KennaSecurity/toolkit/tree/master/tasks/connectors/contrast). Note that I changed the default import from vulns to findings as the latter betters suites the Cobalt data format.

On top of that, I
- removed an unused option (3b0b9c9abc4e8604567e9d94b38ecfd954c5a13d),
- added a missing option to the tasks metadata (ae48bca939a62ca327437f184ed3f2528b31345d), and
- added the `status` and `scanner_score` fields for vulns.