### PR TITLE
Tweak what information Edgescan sends to Kenna.

### DIFF
--- a/tasks/connectors/edgescan/lib/edgescan_asset.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_asset.rb
@@ -23,6 +23,10 @@ module Kenna
           "#{data['name']} (ES#{id})"
         end
 
+        def application?
+          data["type"] == "app"
+        end
+
         def location_specifiers
           @location_specifiers ||= @data["location_specifiers"].map do |specifier|
             EdgescanLocationSpecifier.new(self, specifier)

--- a/tasks/connectors/edgescan/lib/edgescan_definition.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_definition.rb
@@ -12,7 +12,7 @@ module Kenna
 
         def to_kenna_definition
           {
-            "scanner_type" => "Edgescan",
+            "scanner_type" => scanner_type,
             "scanner_identifier" => data["id"],
             "name" => data["name"],
             "description" => data["description_src"],
@@ -23,6 +23,10 @@ module Kenna
         end
 
         private
+
+        def scanner_type
+          data["layer"] == 7 ? "EdgescanApp" : "EdgescanNet"
+        end
 
         def cves
           data["cves"].empty? ? nil : data["cves"].join(",")

--- a/tasks/connectors/edgescan/lib/edgescan_location_specifier.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_location_specifier.rb
@@ -24,7 +24,7 @@ module Kenna
         end
 
         def to_kenna_asset
-          base = { "external_id" => external_asset_id, "application" => asset.application_id, "tags" => asset.tags }
+          base = { "external_id" => external_asset_id, "tags" => asset.tags }
 
           base["ip_address"] = location if type == "ip"
           base["hostname"] = location if type == "hostname"

--- a/tasks/connectors/edgescan/lib/edgescan_location_specifier.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_location_specifier.rb
@@ -26,9 +26,13 @@ module Kenna
         def to_kenna_asset
           base = { "external_id" => external_asset_id, "tags" => asset.tags }
 
-          base["ip_address"] = location if type == "ip"
-          base["hostname"] = location if type == "hostname"
           base["url"] = location if type == "url"
+          base["hostname"] = location if type == "hostname"
+          base["ip_address"] = location if type == "ip"
+          base["ip_address"] = location.split("-").first if type == "block"
+          base["ip_address"] = location.split("/").first if type == "cidr"
+
+          base["application"] = asset.application_id if asset.application? && type == "url"
 
           base
         end

--- a/tasks/connectors/edgescan/lib/edgescan_vulnerability.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_vulnerability.rb
@@ -25,7 +25,7 @@ module Kenna
 
         def to_kenna_vulnerability
           {
-            "scanner_type" => "Edgescan",
+            "scanner_type" => scanner_type,
             "scanner_identifier" => data["definition_id"],
             "created_at" => data["created_at"],
             "last_seen_at" => data["updated_at"],
@@ -36,7 +36,7 @@ module Kenna
         end
 
         def to_corresponding_kenna_asset
-          { "external_id" => external_asset_id, "application" => asset.application_id, "tags" => asset.tags }
+          { "external_id" => external_asset_id, "tags" => asset.tags }
         end
 
         def external_asset_id
@@ -44,6 +44,10 @@ module Kenna
         end
 
         private
+
+        def scanner_type
+          data["layer"] == "application" ? "EdgescanApp" : "EdgescanNet"
+        end
 
         def details
           data["details"].map { |detail| "#{detail_title(detail)}#{detail['src']}" }


### PR DESCRIPTION
# Requirements
![image](https://user-images.githubusercontent.com/53298534/139852008-e833c71b-4787-4c31-a0ce-b85c09b3ea43.png)

# Changes in this PR

- Updated `scanner_type` to be either `EdgescanNet` or `EdgescanApp` depending on the layer of the vulnerability.
- Made it so assets no longer set `application`.

# Questions

We also had two quick questions that came up during development.

### Question 1: No more application ID

Just wanted to verify if we read you right for points `a.ii` and `b.ii`:
![image](https://user-images.githubusercontent.com/53298534/139852245-4047d6a4-2972-4c62-8aa6-45c4ddfa3b54.png)

We've changed it so that assets no longer have an application ID. This means that they will no longer be grouped together in the Applications view on the frontend. We've made this change to both the network and application assets. 


### Question 2: Handling IP blocks

Points `a.i` and `b.i` are fine for the majority of cases:
![image](https://user-images.githubusercontent.com/53298534/139852359-f1fe854d-f4ea-42b4-bb22-b44218a33bc0.png)

We just wanted to double check with you about a rare case. 

Assets on Edgescan can also have IP block locators. For example an asset may have a locator that looks like this: `192.168.0.1-50`. This would mean that the asset has 50 IPs, everything between `192.168.0.1` and `192.168.0.50`.

At the moment, if the connector comes across an Edgescan asset with an IP block it just creates a single Kenna asset with an external ID locator that looks something like this:
```ruby
{ external_id: "ES123:321 block 192.168.0.1-50" }
```

Would it be prefarrable that instead of creating a single Kenna asset we instead create one asset per each individual IP address? So in this example we would create 50 Kenna assets like so:
```ruby
{ ip: "192.168.0.1" }
{ ip: "192.168.0.2" }
{ ip: "192.168.0.3" }
...
{ ip: "192.168.0.48" }
{ ip: "192.168.0.49" }
{ ip: "192.168.0.50" }
```