### PR TITLE
Add a helper method to fail tasks with a non-zero status code

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -74,6 +74,11 @@ module Kenna
         end
       end
 
+      def fail_task(message)
+        print_error(message)
+        exit 1
+      end
+
       ###
       ### Helper to read a file consistently
       ###

--- a/spec/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task_spec.rb
+++ b/spec/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Kenna::Toolkit::WhitehatSentinelTask do
       end
 
       it "exits the script" do
-        expect { task.run(options) }.to raise_error(SystemExit)
+        expect { task.run(options) }.to raise_error(SystemExit) { |e| expect(e.status).to_not be_zero }
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Kenna::Toolkit::WhitehatSentinelTask do
       let(:valid) { false }
 
       it "exits the script" do
-        expect { task.run(options) }.to raise_error(SystemExit)
+        expect { task.run(options) }.to raise_error(SystemExit) { |e| expect(e.status).to_not be_zero }
       end
     end
   end

--- a/tasks/base.rb
+++ b/tasks/base.rb
@@ -48,11 +48,10 @@ module Kenna
 
         # if we do have missing ones, lets warn the user here and return
         unless missing_options.empty?
-          print_error "Required options missing, cowardly refusing to continue!"
           missing_options.each do |arg|
             print_error "Missing! #{arg[:name]}: #{arg[:description]}"
           end
-          exit
+          fail_task "Required options missing, cowardly refusing to continue!"
         end
 
         # No missing arguments, so let's add in our default arguments now

--- a/tasks/connectors/aws_guardduty/aws_guardduty.rb
+++ b/tasks/connectors/aws_guardduty/aws_guardduty.rb
@@ -209,8 +209,7 @@ module Kenna
           end
         rescue Aws::GuardDuty::Errors::ServiceError => e
           # rescues all errors returned by Amazon Inspector
-          print_error "Irrecoverable error connecting to AWS, exiting: #{e}"
-          exit
+          fail_task "Irrecoverable error connecting to AWS, exiting: #{e}"
         end
 
         findings

--- a/tasks/connectors/aws_inspector/aws_inspector.rb
+++ b/tasks/connectors/aws_inspector/aws_inspector.rb
@@ -173,8 +173,7 @@ module Kenna
         rescue Aws::Inspector::Errors::ServiceError => e
           # rescues all errors returned by Amazon Inspector
           print_error "Irrecoverable error connecting to AWS!"
-          print_error e.inspect
-          exit
+          fail_task e.inspect
         end
 
         findings

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -33,10 +33,7 @@ module Kenna
         def build_score_map(mapping)
           mapping.split(",").each do |score|
             x = score.split("-")
-            unless (0..100).include?(x[1].to_i) && x[1] !~ /\D/
-              puts "ERROR: Invalid Score Mapping. Quitting process."
-              exit
-            end
+            fail_task "ERROR: Invalid Score Mapping. Quitting process." unless (0..100).include?(x[1].to_i) && x[1] !~ /\D/
           end
 
           score_map = {}

--- a/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task.rb
+++ b/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task.rb
@@ -82,25 +82,16 @@ module Kenna
         output_dir = "#{$basedir}/#{@options[:output_directory]}"
 
         # Validate given options
-        unless %i[advanced legacy].include? scoring_system
-          print_error "The #{@options[:whitehat_scoring]} scoring system is not supported.  Choices are legacy and advanced."
-          exit
-        end
+        fail_task "The #{@options[:whitehat_scoring]} scoring system is not supported.  Choices are legacy and advanced." unless %i[advanced legacy].include? scoring_system
 
-        unless page_size.positive?
-          print_error "The page size of #{@options[:whitehat_page_size]} is not supported."
-          exit
-        end
+        fail_task "The page size of #{@options[:whitehat_page_size]} is not supported. It must be a positive number." unless page_size.positive?
 
-        print_error "The batch size of #{@options[:kenna_batch_size]} is not supported." if @batch_size.negative?
+        fail_task "The batch size of #{@options[:kenna_batch_size]} is not supported. It may not be a negative number." if @batch_size.negative?
 
         mapper = Kenna::Toolkit::WhitehatSentinel::Mapper.new(scoring_system)
 
         client = Kenna::Toolkit::WhitehatSentinel::ApiClient.new(api_key: key, page_size: page_size)
-        unless client.api_key_valid?
-          print_error "The Whitehat API does not accept the provided API key."
-          exit
-        end
+        fail_task "The Whitehat API does not accept the provided API key." unless client.api_key_valid?
 
         filter = {}
         filter[:query_severity] = query_severity
@@ -127,8 +118,7 @@ module Kenna
         end
         kdi_connector_kickoff @kenna_connector_id, @kenna_api_host, @kenna_api_key if @kenna_connector_id && @kenna_api_host && @kenna_api_key
       rescue Kenna::Toolkit::WhitehatSentinel::ApiClient::Error
-        print_error "Problem connecting to Whitehat API, please verify the API key."
-        exit
+        fail_task "Problem connecting to Whitehat API, please verify the API key."
       end
 
       def sanitize(raw_url)


### PR DESCRIPTION
As we move to a world where the toolkit is run in hosted containers, having a non-zero status code will make failures easier to detect.  Passing a status value to [`exit`](https://ruby-doc.org/core-2.6.4/SystemExit.html) causes the Ruby process to terminate with the given value as it's status code.