### PR TITLE
Exit with non-zero status code in a few more places

### DIFF
--- a/tasks/connectors/bitsight/bitsight.rb
+++ b/tasks/connectors/bitsight/bitsight.rb
@@ -85,8 +85,7 @@ module Kenna
         if valid_bitsight_api_key?
           print_good "Valid key, proceeding!"
         else
-          print_error "Unable to proceed, invalid key for Bitsight?"
-          return
+          fail_task "Unable to proceed, invalid key for Bitsight?"
         end
         fm = Kenna::Toolkit::Data::Mapping::DigiFootprintFindingMapper.new(@output_dir, @options[:input_directory], @options[:df_mapping_filename])
         bitsight_findings_and_create_kdi(bitsight_create_benign_findings, benign_finding_grades, company_guids, fm, @options[:bitsight_lookback])

--- a/tasks/connectors/expanse/expanse.rb
+++ b/tasks/connectors/expanse/expanse.rb
@@ -80,10 +80,7 @@ module Kenna
         @vuln_defs = []
 
         # verify we have a good key before proceeding
-        unless @client.successfully_authenticated?
-          print_error "Unable to proceed, invalid key for Expanse?"
-          return
-        end
+        fail_task "Unable to proceed, invalid key for Expanse?" unless @client.successfully_authenticated?
         print_good "Valid key, proceeding!"
 
         if @options[:debug]

--- a/tasks/connectors/expanse_issues/expanse_issues.rb
+++ b/tasks/connectors/expanse_issues/expanse_issues.rb
@@ -101,10 +101,7 @@ module Kenna
         @vuln_defs = []
 
         # verify we have a good key before proceeding
-        unless @client.successfully_authenticated?
-          print_error "Unable to proceed, invalid key for Expanse?"
-          return
-        end
+        fail_task "Unable to proceed, invalid key for Expanse?" unless @client.successfully_authenticated?
         print_good "Valid key, proceeding!"
 
         create_kdi_from_issues(@options[:expanse_page_size], @issue_types, @priorities, @tags, @fm, @options[:lookback])

--- a/tasks/connectors/security_scorecard/security_scorecard.rb
+++ b/tasks/connectors/security_scorecard/security_scorecard.rb
@@ -220,12 +220,9 @@ module Kenna
         client = Kenna::Toolkit::Ssc::Client.new(ssc_api_key)
 
         ### Basic Sanity checking
-        if client.successfully_authenticated?
-          print_good "Successfully authenticated!"
-        else
-          print_error "Unable to proceed, invalid key for Security Scorecard?"
-          return
-        end
+        fail_task "Unable to proceed, invalid key for Security Scorecard?" unless client.successfully_authenticated?
+
+        print_good "Successfully authenticated!"
 
         unless ssc_portfolio_ids
           ssc_portfolio_ids = []

--- a/toolkit.rb
+++ b/toolkit.rb
@@ -24,7 +24,7 @@ args_array.each do |arg|
     print_error "FATAL! Invalid Argument: #{arg}"
     print_error "All arguments should take the form [name]=[value]"
     print_error "Multiple arguments should be separated by colons (:) or spaces"
-    exit
+    exit 1
   end
 
   # set the arg value into the hash
@@ -35,7 +35,7 @@ end
 unless args[:task]
   print_error "FATAL! Missing required argument: 'task'"
   print_usage
-  exit
+  exit 1
 end
 
 # handle task request
@@ -49,5 +49,6 @@ else
     task_class.new.run(args)
   else
     puts "[!] Error. Unknown task requested!"
+    exit 1
   end
 end


### PR DESCRIPTION
After #242, I found a few more places that can call `fail_task` when exiting.  They were missed initially because they were calling `return` instead of `exit`.

Additionally, early on in the script we will break if given improperly formatted command line arguments, we should exit with a non-zero status code there, also.