### PR TITLE
Fixes:

### DIFF
--- a/tasks/connectors/burp/burp_readme.md
+++ b/tasks/connectors/burp/burp_readme.md
@@ -27,7 +27,7 @@ Complete list of Options:
 
 | Option | Required | Description | default |
 | --- | --- | --- | --- |
-| burp_api_host | true | Burp instance hostname, e.g. http://burp.example.com:8080  | n/a |
+| burp_api_host | true | Burp instance hostname, e.g. http://burp.example.com:8080 . Must escape hostname in command line script, e.g. \\"http://burp.example.com:8080\"  | n/a |
 | burp_schedule_id | true | A list of Burp Schedule ID (comma separated) | n/a |
 | burp_issue_severity | false | A list of [info, low, medium, high] (comma separated) | [info, low, medium, high] |
 | burp_api_token | true | Burp User API token | n/a |

--- a/tasks/connectors/burp/burp_task.rb
+++ b/tasks/connectors/burp/burp_task.rb
@@ -23,7 +23,7 @@ module Kenna
             { name: "burp_issue_severity",
               type: "string",
               required: false,
-              default: "[info, low, medium, high]",
+              default: "info, low, medium, high",
               description: "A list of [info, low, medium, high] (comma separated)" },
             { name: "burp_api_token",
               type: "api_key",
@@ -88,13 +88,13 @@ module Kenna
 
               print_good("Processed #{[pos + @max_issues, total_issues].min} of #{total_issues} issues for scan ##{scan_id}.")
               kdi_upload(@output_directory, "burp_scan_#{scan_id}_report_#{pos}.json", @kenna_connector_id, @kenna_api_host, @kenna_api_key, @skip_autoclose, @retries, @kdi_version)
-              kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
               pos += @max_issues
             end
           else
             print("No scan found for schedule #{schedule_id}")
           end
         end
+        kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
       end
 
       private
@@ -129,7 +129,7 @@ module Kenna
       def extract_asset(issue)
         {
           "url" => "#{issue['origin']}#{issue['path']}",
-          "application" => issue["origin"]
+          "application" => issue["origin"].gsub(%r{https://|http://}, "")
         }.compact
       end
 


### PR DESCRIPTION
- doesn't work if you don't pass in burp_issue_severity.
- kdi_connector_kickoff needs to move to AFTER the scan report is processed
- application_identifier can be the URL with the https:\\ stripped
- added doc for burp_api_host parameter needs escaping