### PR TITLE
Fixed wrong usage of kdi_connector_kickoff

### DIFF
--- a/tasks/connectors/bugcrowd/bugcrowd_task.rb
+++ b/tasks/connectors/bugcrowd/bugcrowd_task.rb
@@ -99,10 +99,10 @@ module Kenna
           break unless (response[:count]).positive?
 
           kdi_upload(@output_directory, "bugcrowd_submissions_report_#{offset}.json", @kenna_connector_id, @kenna_api_host, @kenna_api_key, @skip_autoclose, @retries, @kdi_version)
-          kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
           offset += response[:count]
           print_error "Reached max Bugcrowd API offset value of 9900" if offset > 9900
         end
+        kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
       end
 
       private


### PR DESCRIPTION
I found it had the same problem that the other connectors pushed by me. Now is fixed.