### PR TITLE
Cleanly handle initial API failures for tasks

### DIFF
--- a/tasks/connectors/aqua/aqua.rb
+++ b/tasks/connectors/aqua/aqua.rb
@@ -85,6 +85,7 @@ module Kenna
         @kenna_connector_id = @options[:kenna_connector_id]
 
         token = aqua_get_token(aqua_url, username, password)
+        fail_task "Unable to authenticate with Aqua, please check credentials" unless token
 
         if container_data
           print_debug "Container_data flag set to true"

--- a/tasks/connectors/aqua/lib/aqua_helper.rb
+++ b/tasks/connectors/aqua/lib/aqua_helper.rb
@@ -19,21 +19,18 @@ module Kenna
           "password": password.to_s
         }
 
-        # print_debug "#{aqua_auth_api}"
-        # print_debug "#{auth_headers}"
-        # print_debug "#{auth_body}"
-        auth_response = http_post(aqua_auth_api, @headers, payload.to_json)
-        return nil unless auth_response
-
         begin
+          auth_response = http_post(aqua_auth_api, @headers, payload.to_json)
           auth_json = JSON.parse(auth_response.body)
+
+          token = auth_json["token"]
+          print_debug token.to_s
+          token
         rescue JSON::ParserError
           print_error "Unable to process Auth Token response!"
+        rescue StandardError => e
+          print_error "Failed to retrieve Auth Token #{e.message}"
         end
-
-        token = auth_json["token"]
-        print_debug token.to_s
-        token
       end
 
       def aqua_get_vuln(aqua_url, token, pagesize, pagenum)

--- a/tasks/connectors/burp/burp_task.rb
+++ b/tasks/connectors/burp/burp_task.rb
@@ -95,6 +95,8 @@ module Kenna
           end
         end
         kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
+      rescue Kenna::Toolkit::Burp::BurpClient::ApiError
+        fail_task "Unable to retrieve scan, please check credentials"
       end
 
       private

--- a/tasks/connectors/burp/lib/burp_client.rb
+++ b/tasks/connectors/burp/lib/burp_client.rb
@@ -6,6 +6,8 @@ module Kenna
   module Toolkit
     module Burp
       class BurpClient
+        class ApiError < StandardError; end
+
         def initialize(host, api_token)
           @endpoint = "#{host}/graphql/v1"
           @headers = { "content-type": "application/json", "Authorization": api_token }
@@ -13,6 +15,8 @@ module Kenna
 
         def get_last_schedule_scan(schedule_id)
           response = http_post(@endpoint, @headers, query(last_schedule_scan_query, schedule_id: schedule_id))
+          raise ApiError unless response
+
           JSON.parse(response)["data"]["scans"].first
         end
 

--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -69,6 +69,7 @@ module Kenna
 
         findings_json = cobalt_get_findings(cobalt_api_token, cobalt_org_token)
         print_debug "findings json = #{findings_json}"
+        fail_task "Unable to retrieve findings, please check credentials" if findings_json.nil?
 
         severity_map = { "high" => 7, "medium" => 5, "low" => 3 } # converter
         state_map = { "need_fix" => "new", "wont_fix" => "risk_accepted", "valid_fix" => "resolved", "check_fix" => "in_progress", "carried_over" => "new" }

--- a/tasks/connectors/contrast/contrast.rb
+++ b/tasks/connectors/contrast/contrast.rb
@@ -125,6 +125,7 @@ module Kenna
         if contrast_include_vulns == true
           # Fetch vulnerabilities from the Contrast API
           vulns = @client.get_vulns(contrast_application_tags, contrast_environments, contrast_severities)
+          fail_task "Unable to retrieve vulnerabilities, please check credentials" if vulns.nil?
 
           # Loop through the vulnerabilities found
           vulns.each_with_index do |v, i|
@@ -199,6 +200,7 @@ module Kenna
         if contrast_include_libs == true
           # Fetch a list of relevant applications
           apps = @client.get_application_ids(contrast_application_tags)
+          fail_task "Unable to retrieve applications, please check credentials" if apps.nil?
 
           # Convert to an array of strings
           apps = apps.map { |f| f["app_id"] }

--- a/tasks/connectors/contrast/lib/client.rb
+++ b/tasks/connectors/contrast/lib/client.rb
@@ -26,6 +26,8 @@ module Kenna
           while more_results
             url = "#{@base_url}/orgtraces/filter?expand=application&offset=#{offset}&limit=#{limit}&applicationTags=#{tags}&environments=#{environments}&severities=#{severities}&licensedOnly=true"
             response = http_get(url, @headers)
+            return nil if response.nil?
+
             body = JSON.parse response.body
 
             # prepare the next request
@@ -89,6 +91,8 @@ module Kenna
           print_debug "Getting applications from the Contrast API"
           url = "#{@base_url}/applications/filter/short?filterTags=#{tags}"
           response = http_get(url, @headers)
+          return nil if response.nil?
+
           temp = JSON.parse response.body
           temp["applications"]
         end

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -73,6 +73,8 @@ module Kenna
         end
 
         kenna_api.kickoff
+      rescue Kenna::Toolkit::Edgescan::EdgescanApi::ApiError
+        fail_task "Unable to retrieve assets, please check credentials"
       end
     end
   end

--- a/tasks/connectors/edgescan/lib/edgescan_api.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_api.rb
@@ -4,6 +4,8 @@ module Kenna
   module Toolkit
     module Edgescan
       class EdgescanApi
+        class ApiError < StandardError; end
+
         def initialize(options)
           @edgescan_token = options[:edgescan_token]
           @page_size = options[:edgescan_page_size].to_i
@@ -61,6 +63,8 @@ module Kenna
 
         def query(resource, query_payload, unwrap: true)
           response = http_post("#{base_url}/api/v1/#{resource}/query.json", { "X-API-TOKEN": @edgescan_token }, query_payload)
+          raise ApiError unless response
+
           json = JSON.parse(response.body)
           unwrap ? json[resource] : json
         end

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -74,6 +74,7 @@ module Kenna
         # Generate Temporary Lacework API Token
         puts "Generating Temporary Lacework API Token"
         temp_api_token = generate_temporary_lacework_api_token(lacework_account, lacework_api_key, lacework_api_secret)
+        fail_task "Unable to generate API token, please check credentials" unless temp_api_token
 
         # Pull assets and vulns from Lacework
         puts "Pulling asset and vulnerability data from Lacework API"

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -27,6 +27,11 @@ module Kenna
           http.request(request)
         end
 
+        if response.code != 200
+          print_debug response.message
+          return nil
+        end
+
         JSON.parse(response.body)["data"].last["token"]
       end
 

--- a/tasks/connectors/ms_defender_atp/lib/ms_defender_atp_helper.rb
+++ b/tasks/connectors/ms_defender_atp/lib/ms_defender_atp_helper.rb
@@ -105,6 +105,12 @@ module Kenna
         json
       end
 
+      def valid_auth_token?
+        atp_get_auth_token if @token.nil?
+
+        !@token.nil?
+      end
+
       def atp_get_auth_token
         print_debug "Getting token"
         oauth_url = "https://#{@atp_oath_url}/#{@tenant_id}/oauth2/token"

--- a/tasks/connectors/ms_defender_atp/ms_defender_atp.rb
+++ b/tasks/connectors/ms_defender_atp/ms_defender_atp.rb
@@ -131,6 +131,8 @@ module Kenna
         max_retries = @options[:max_retries]
 
         set_client_data(atp_tenant_id, atp_client_id, atp_client_secret, atp_api_host, atp_oath_host, file_cleanup)
+        fail_task "Unable to retrieve auth token, please check credentials" unless valid_auth_token?
+
         asset_next_link = nil
         asset_json_response = atp_get_machines
         asset_next_link = asset_json_response.fetch("@odata.nextLink") if asset_json_response.key?("@odata.nextLink")

--- a/tasks/connectors/ms_defender_tvm/lib/ms_defender_tvm_helper.rb
+++ b/tasks/connectors/ms_defender_tvm/lib/ms_defender_tvm_helper.rb
@@ -79,6 +79,12 @@ module Kenna
         json
       end
 
+      def valid_auth_token?
+        tvm_get_auth_token if @token.nil?
+
+        !@token.nil?
+      end
+
       def tvm_get_auth_token
         print_debug "Getting token"
         oauth_url = "https://#{@tvm_oath_url}/#{@tenant_id}/oauth2/token"

--- a/tasks/connectors/ms_defender_tvm/ms_defender_tvm.rb
+++ b/tasks/connectors/ms_defender_tvm/ms_defender_tvm.rb
@@ -99,6 +99,7 @@ module Kenna
         @max_retries = @options[:max_retries]
 
         set_client_data(tvm_tenant_id, tvm_client_id, tvm_client_secret, tvm_api_host, tvm_oath_host, tvm_page_size)
+        fail_task "Unable to retrieve auth token, please check credentials" unless valid_auth_token?
 
         morevuln = true
         asset_count = 0

--- a/tasks/connectors/nozomi/nozomi.rb
+++ b/tasks/connectors/nozomi/nozomi.rb
@@ -88,6 +88,7 @@ module Kenna
           pagenum += 1
 
           issue_json = nozomi_get_issues(nozomi_user, nozomi_password, nozomi_api_host, nozomi_node_types, nozomi_page_size, pagenum)
+          fail_task "Unable to retrieve issues, please check credentials" if issue_json.nil?
 
           print_debug "issue json = #{issue_json}"
 

--- a/tasks/connectors/riskiq/lib/riskiq_helper.rb
+++ b/tasks/connectors/riskiq/lib/riskiq_helper.rb
@@ -3,6 +3,8 @@
 module Kenna
   module Toolkit
     module RiskIQHelper
+      class ApiError < StandardError; end
+
       @api_url = nil
       @pull_incremental = nil
       @uploaded_files = nil
@@ -194,7 +196,7 @@ module Kenna
 
           endpoint = "#{@api_url}globalinventory/search?size=#{riskiq_page_size}&recent=true&mark=#{mark}"
           response = http_post(endpoint, @headers, query)
-          return if response.nil?
+          raise ApiError if response.nil?
 
           begin
             result = JSON.parse(response.body)

--- a/tasks/connectors/riskiq/riskiq.rb
+++ b/tasks/connectors/riskiq/riskiq.rb
@@ -138,6 +138,8 @@ module Kenna
         return unless @kenna_connector_id && @kenna_api_host && @kenna_api_key
 
         connector_kickoff
+      rescue Kenna::Toolkit::RiskIQHelper::ApiError
+        fail_task "Unable to retrieve data from API, please check credentials"
       end
     end
   end

--- a/tasks/connectors/snyk/snyk.rb
+++ b/tasks/connectors/snyk/snyk.rb
@@ -88,6 +88,8 @@ module Kenna
         from_date = (Date.today - retrieve_from.to_i).strftime("%Y-%m-%d")
 
         org_json = snyk_get_orgs(snyk_api_token)
+        fail_task "Unable to retrieve data from API, please check credentials" if org_json.nil?
+
         projects = []
         project_ids = []
         org_ids = []

--- a/tasks/connectors/snyk_findings/snyk_findings.rb
+++ b/tasks/connectors/snyk_findings/snyk_findings.rb
@@ -88,6 +88,8 @@ module Kenna
         from_date = (Date.today - retrieve_from.to_i).strftime("%Y-%m-%d")
 
         org_json = snyk_get_orgs(snyk_api_token)
+        fail_task "Unable to retrieve data from API, please check credentials" if org_json.nil?
+
         projects = []
         project_ids = []
         org_ids = []

--- a/tasks/connectors/snyk_v2/snyk_v2.rb
+++ b/tasks/connectors/snyk_v2/snyk_v2.rb
@@ -97,6 +97,8 @@ module Kenna
         from_date = (Date.today - retrieve_from.to_i).strftime("%Y-%m-%d")
 
         org_json = snyk_get_orgs(snyk_api_token)
+        fail_task "Unable to retrieve data from API, please check credentials" if org_json.nil?
+
         projects = []
         project_ids = []
         org_ids = []

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -54,6 +54,8 @@ module Kenna
             uri = URI.parse(url)
             auth_path = "#{uri.path}?#{uri.query}"
             response = http_get(url, hmac_auth_options(auth_path))
+            return unless response
+
             result = JSON.parse(response.body)
             applications = result["_embedded"]["applications"]
 
@@ -87,6 +89,8 @@ module Kenna
             uri = URI.parse(url)
             auth_path = "#{uri.path}?#{uri.query}"
             response = http_get(url, hmac_auth_options(auth_path))
+            return unless response
+
             result = JSON.parse(response.body)
             cwes = result["_embedded"]["cwes"]
 
@@ -107,6 +111,8 @@ module Kenna
             uri = URI.parse(url)
             auth_path = "#{uri.path}?#{uri.query}"
             response = http_get(url, hmac_auth_options(auth_path))
+            return unless response
+
             result = JSON.parse(response.body)
             categories = result["_embedded"]["categories"]
 

--- a/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
+++ b/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
@@ -95,6 +95,7 @@ module Kenna
         client.cwe_recommendations(500)
 
         app_list = client.applications(page_size, custom_field_name, custom_field_value)
+        fail_task "Unable to retrieve data from API, please check credentials" if app_list.nil?
 
         app_list.each do |application|
           guid = application.fetch("guid")

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -35,6 +35,8 @@ module Kenna
             uri = URI.parse(url)
             auth_path = "#{uri.path}?#{uri.query}"
             response = http_get(url, hmac_auth_options(auth_path))
+            return unless response
+
             result = JSON.parse(response.body)
             applications = result["_embedded"]["applications"]
 
@@ -60,6 +62,8 @@ module Kenna
             uri = URI.parse(url)
             auth_path = "#{uri.path}?#{uri.query}"
             response = http_get(url, hmac_auth_options(auth_path))
+            return unless response
+
             result = JSON.parse(response.body)
             categories = result["_embedded"]["categories"]
 

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -70,6 +70,7 @@ module Kenna
         client.category_recommendations(page_size)
 
         app_list = client.applications(page_size)
+        fail_task "Unable to retrieve data from API, please check credentials" if app_list.nil?
 
         app_list.each do |application|
           guid = application.fetch("guid")

--- a/tasks/connectors/wiz/lib/wiz_client.rb
+++ b/tasks/connectors/wiz/lib/wiz_client.rb
@@ -12,6 +12,7 @@ module Kenna
           @auth_endpoint = "https://#{auth_endpoint}"
           @output_directory = output_dir
           token = request_wiz_api_token(client_id, client_secret)
+          @valid_token = !token.nil?
           @header = { "content-type" => "application/json", "Authorization" => "Bearer #{token}" }
           @get_subs_variables = "{ \"first\" : 500 }"
           # @CreateReport_variables = {"input": {"name": "", "type": "VULNERABILITIES", "params": {"subscriptionIds": [""], "projectId": "*"}}}
@@ -190,6 +191,10 @@ module Kenna
               }".delete("\n")
         end
 
+        def valid_token?
+          @valid_token
+        end
+
         # Methods used in this script
         # Used for creating strings from the variables hash. String is used to update query string
         def transform_hash_to_string(hash)
@@ -213,6 +218,8 @@ module Kenna
           payload = "grant_type=client_credentials&client_id=#{client_id}&client_secret=#{client_secret}&audience=beyond-api"
           auth_url = "#{@auth_endpoint}.wiz.io/oauth/token"
           access_code_call = http_post(auth_url, headers, payload)
+          return unless access_code_call
+
           JSON.parse(access_code_call)["access_token"]
         end
 

--- a/tasks/connectors/wiz/wiz_task.rb
+++ b/tasks/connectors/wiz/wiz_task.rb
@@ -93,7 +93,7 @@ module Kenna
         kdi_version = 2
 
         client = Kenna::Toolkit::Wiz::WizClient.new(client_id, client_secret, @output_directory, @options[:wiz_auth_endpoint], @options[:wiz_api_host])
-
+        fail_task "Unable to retrieve API token, please check credentials" unless client.valid_token?
         print_debug "report object types count #{report_object_types.size} and #{report_object_types}"
 
         # @create_report_variables[:input][:params][:vulnerabilities_since] = vulnerabilities_since if vulnerabilities_since != ""


### PR DESCRIPTION
Following up on #242 and #243, this PR detects when a task's initial API call fails, assumes the failure is due to incorrect credentials and uses `fail_task` to exit the task with an error message and non-zero status code.

Most tasks use the `http_get` and `http_post` helper methods, which retry on failure but swallow errors.  When retries are exhausted, those helpers simply return `nil` instead of raising an error.  Instead of changing that design, which feels very invasive, this PR detects when we receive a `nil` response and assumes it is due to an error.  Additionally, it only tries to detect failure on the task's first API call.  If we have valid creds but the API breaks partway through we'll likely get a gross failure, but that seems less likely than being given bad creds.