### PR TITLE
Fail the task if we can't upload to Kenna or if the resulting ConnectorRun fails

### DIFF
--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -263,6 +263,13 @@ module Kenna
             # check our value to see if we need to keep going
             running = connector_check_json["running"]
           end
+
+          connector_run_status_response = RestClient::Request.execute(
+            method: :get,
+            url: "#{connector_check_endpoint}/connector_runs/#{query_response_json['connector_run_id']}",
+            headers: headers
+          )
+          connector_run_status_json = JSON.parse(connector_run_status_response)
         rescue RestClient::Exceptions::OpenTimeout => e
           print_error "Timeout: #{e.message}..."
         rescue RestClient::UnprocessableEntity => e
@@ -289,7 +296,7 @@ module Kenna
         end
 
         print_good "Done!"
-        query_response_json
+        connector_run_status_json
       end
 
       private

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -151,9 +151,11 @@ module Kenna
         # upload it
         if connector_id && connector_id != -1
           kenna = Kenna::Api::Client.new(api_token, api_host)
-          kenna.run_files_on_connector(connector_id, upload_ids, max_retries)
+          result = kenna.run_files_on_connector(connector_id, upload_ids, max_retries)
+          fail_task "File upload failed" unless result
+          fail_task "Connector run (id #{result['id']}) failed" unless result["success"]
         else
-          print_error "Invalid Connector ID (#{connector_id}), unable to upload."
+          fail_task "Invalid Connector ID (#{connector_id}), unable to upload."
         end
       end
 

--- a/spec/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task_spec.rb
+++ b/spec/tasks/connectors/whitehat_sentinel/whitehat_sentinel_task_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Kenna::Toolkit::WhitehatSentinelTask do
     let(:valid) { true }
     let(:vuln) { { found: "2016-03-21T15:48:48Z", status: "accepted", severity: "4", risk: 5, description: { description: "text" }, solution: { solution: "text" } } }
     let(:asset) { { asset: { id: 12 } } }
-    let(:kenna_client) { instance_double(Kenna::Api::Client, upload_to_connector: { "data_file" => 12 }, run_files_on_connector: {}) }
+    let(:connector_run_success) { true }
+    let(:kenna_client) { instance_double(Kenna::Api::Client, upload_to_connector: { "data_file" => 12 }, run_files_on_connector: { "success" => connector_run_success }) }
 
     before do
       allow(Kenna::Toolkit::WhitehatSentinel::ApiClient).to receive(:new) { api_client }
@@ -21,6 +22,13 @@ RSpec.describe Kenna::Toolkit::WhitehatSentinelTask do
 
     it "succeeds" do
       expect { task.run(options) }.to_not raise_error
+    end
+
+    context "when the connector run fails" do
+      let(:connector_run_success) { false }
+      it "exits the script" do
+        expect { task.run(options) }.to raise_error(SystemExit) { |e| expect(e.status).to_not be_zero }
+      end
     end
 
     context "when using an unknown scoring system" do


### PR DESCRIPTION
Two pieces to this change:
1. The Kenna API client now grabs the results of the ConnectorRun from the API once the connector is no longer running and returns that as the result of `run_files_on_connector`
2. `run_files_on_kenna_connector` inspects that API response and if the connector run was not successful, it will print a message and exit with a non-zero status code.  This will help us detect unsuccessful CRs when the toolkit is running inside of a hosted container.