### PR TITLE
Implemented Checkmarx SAST connector

### DIFF
--- a/tasks/connectors/checkmarx_sast/README.md
+++ b/tasks/connectors/checkmarx_sast/README.md
@@ -1,0 +1,54 @@
+## Running Checkmarx SAST task
+
+This toolkit brings in data from Checkmarx SAST (https://partners9x.checkmarx.net/cxrestapi/)
+
+To run this task you need the following information from Checkmarx SAST:
+
+1. Username
+2. Password
+3. Client ID
+4. Client Secret
+5. grant_type
+6. scope (optional)
+
+## This Task will use the Checkmarx SAST API to
+
+- Get a list of Projects currently present in the user's Checkmarx SAST account.
+- Get a list of Scans in the user's Checkmarx SAST account associated with each Project.
+- Generate Report Id on each scan.
+- Get a list of scan reports using newly generated above report id.
+- Output a json file in the Kenna Data Importer (KDI) format.
+- Post the file to Kenna if API Key and Connector ID are provided
+
+
+Complete list of Options:
+
+| Option | Required | Description | default |
+| --- | --- | --- | --- |
+| checkmarx_sast_user | true | Checkmarx SAST username | n/a |
+| checkmarx_sast_password | true | Checkmarx SAST password | n/a |
+| client_id | true | Checkmarx SAST Client ID | n/a |
+| client_secret | true | Checkmarx SAST Client Secret | n/a |
+| grant_type | false | password | n/a |
+| scope | false | access_control_api sast_api | n/a |
+| kenna_api_key | false | Kenna API Key for use with connector option | n/a |
+| kenna_api_host | false | Kenna API Hostname if not US shared | api.kennasecurity.com |
+| kenna_connector_id | false | If set, we'll try to upload to this connector | n/a |
+| output_directory | false | If set, will write a file upon completion. Path is relative to #{$basedir} | output/checkmarx_sast |
+
+## Command Line
+
+See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a json file in the default or specified output directory. You can review the file before attempting to upload to the Kenna directly.
+
+Recommended Steps:
+
+For extracting Image vulnerability data:
+
+    toolkit:latest task=checkmarx_sast checkmarx_sast_console=xxx checkmarx_sast_user=xxx checkmarx_sast_password=xxx
+    checkmarx_sast_base_api_url=partners9x.checkmarx.net/cxrestapi container_data=false kenna_connector_id=15xxxx
+    kenna_api_host=api.sandbox.us.kennasecurity.com kenna_api_key=xxx
+
+For extracting Container vulnerability data in addition to Images:
+
+    toolkit:latest task=checkmarx_sast checkmarx_sast_console=xxx checkmarx_sast_user=xxx checkmarx_sast_password=xxx checkmarx_sast_base_api_url=partners9x.checkmarx.net/cxrestapi container_data=true kenna_connector_id=15xxxx
+    kenna_api_host=api.sandbox.us.kennasecurity.com kenna_api_key=xxx

--- a/tasks/connectors/checkmarx_sast/checkmarx_sast.rb
+++ b/tasks/connectors/checkmarx_sast/checkmarx_sast.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require_relative "lib/checkmarx_sast_helper"
+require "json"
+
+module Kenna
+  module Toolkit
+    class CheckmarxSast < Kenna::Toolkit::BaseTask
+      include Kenna::Toolkit::CheckmarxSastHelper
+
+      def self.metadata
+        {
+          id: "checkmarx_sast",
+          name: "checkmarx_sast Vulnerabilities",
+          description: "Pulls assets and vulnerabilitiies from checkmarx_sast",
+          options: [
+            { name: "checkmarx_sast_console",
+              type: "hostname",
+              required: true,
+              default: nil,
+              description: "Your checkmarx_sast Console hostname (without protocol and port), e.g. app.checkmarx_sastsecurity.com" },
+            { name: "checkmarx_sast_console_port",
+              type: "integer",
+              required: false,
+              default: nil,
+              description: "Your checkmarx_sast Console port, e.g. 8080" },
+            { name: "checkmarx_sast_user",
+              type: "user",
+              required: true,
+              default: nil,
+              description: "checkmarx_sast Username" },
+            { name: "checkmarx_sast_password",
+              type: "password",
+              required: true,
+              default: nil,
+              description: "checkmarx_sast Password" },
+            { name: "client_id",
+              type: "client detail",
+              required: true,
+              default: nil,
+              description: "client id of checkmarx SAST" },
+            { name: "client_secret",
+              type: "client secret ",
+              required: true,
+              default: nil,
+              description: "client secret of checkmarx SAST" },
+            { name: "grant_type",
+              type: "grant access type",
+              required: false,
+              default: "password",
+              description: "grant access type" },
+            { name: "scope",
+              type: "api scope",
+              required: false,
+              default: "access_control_api sast_api",
+              description: "scope API" },
+            { name: "kenna_api_key",
+              type: "api_key",
+              required: false,
+              default: nil,
+              description: "Kenna API Key" },
+            { name: "kenna_api_host",
+              type: "hostname",
+              required: false,
+              default: "api.kennasecurity.com",
+              description: "Kenna API Hostname" },
+            { name: "kenna_connector_id",
+              type: "integer",
+              required: false,
+              default: nil,
+              description: "If set, we'll try to upload to this connector" },
+            { name: "output_directory",
+              type: "filename",
+              required: false,
+              default: "output/checkmarx_sast",
+              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" }
+          ]
+        }
+      end
+
+      def run(opts)
+        super # opts -> @options
+
+        initialze_options
+
+        # Request checkmarx sast auth api to get access token
+        token = request_checkmarx_sast_token
+        fail_task "Unable to authenticate with checkmarx_sast, please check credentials" unless token
+
+        # Request checkmarx sast api to fetch projects using token
+        print_good "Fetching Projects..."
+        projects = fetch_checkmarx_sast_projects(token)
+        print_good "Found Projects - #{projects.try(:size)}"
+        print_good "\n"
+
+        projects.each do |project|
+          print_good "Project Name: #{project['name']}"
+          project_id = project["id"]
+
+          # Request checkmarx sast api to fetch all scans of each project
+          scan_results = fetch_all_scans_of_project(token, project_id)
+          print_good "No Scan Results found for the project - #{project['name']}" unless scan_results.present?
+
+          vuln_severity = { "High" => 9, "Medium" => 6, "Low" => 3, "Informational" => 0 }
+          scan_results.each do |scan|
+            report_id = generate_report_id_from_scan(token, scan["id"])
+            sleep(10)
+            print_good "Fetching Scan Reports..."
+            scan_reports = fetch_scan_reports(token, report_id)
+            print_good "Found Scan reports!!"
+            print_good "\n"
+
+            scan_reports.each_value do |scan_report|
+              application = scan_report.fetch("ProjectName")
+              report_queries = scan_report.fetch("Query")
+              report_queries.each do |query|
+                report_results = query.fetch("Result")
+                report_results.each do |result|
+                  next unless result.instance_of?(Hash)
+
+                  path = result["Path"]
+                  path_node = path.fetch("PathNode")
+                  filename = fetch_pathnode_info(path_node, "FileName") if path.present?
+                  scanner_id = result["NodeId"]
+                  severity = result["Severity"] if result["Severity"].present?
+                  scanner_vulnerability = query["name"].to_s
+                  cwe = "CWE-#{query['cweId']}"
+                  found_date = formatted_date(result["DetectionDate"]) if result["DetectionDate"].present?
+
+                  asset = {
+                    "file" => filename,
+                    "application" => application
+                  }
+                  asset.compact!
+
+                  additional_fields = {
+                    "Team" => scan_report.fetch("Team"),
+                    "group" => query.fetch("group"),
+                    "Language" => query.fetch("Language"),
+                    "DeepLink" => result.fetch("DeepLink"),
+                    "Line" => fetch_pathnode_info(path_node, "Line"),
+                    "Column" => fetch_pathnode_info(path_node, "Column"),
+                    "NodeId" => fetch_pathnode_info(path_node, "NodeId"),
+                    "Name" => fetch_pathnode_info(path_node, "Name"),
+                    "Type" => fetch_pathnode_info(path_node, "Type"),
+                    "Length" => fetch_pathnode_info(path_node, "Length"),
+                    "Snippet" => fetch_snippet(path_node)
+                  }
+                  additional_fields.compact!
+
+                  scanner_score = vuln_severity.fetch(severity)
+
+                  # craft the vuln hash
+                  finding = {
+                    "scanner_identifier" => scanner_id,
+                    "scanner_type" => "CheckmarxSast",
+                    "created_at" => found_date,
+                    "severity" => scanner_score,
+                    "vuln_def_name" => scanner_vulnerability,
+                    "additional_fields" => additional_fields
+                  }
+                  finding.compact!
+
+                  vuln_def = {
+                    "scanner_type" => "CheckmarxSast",
+                    "name" => scanner_vulnerability,
+                    "cwe_identifiers" => cwe
+                  }
+                  vuln_def.compact!
+
+                  # Create the KDI entries
+                  create_kdi_asset_finding(asset, finding)
+                  create_kdi_vuln_def(vuln_def)
+                end
+              end
+            end
+          end
+
+          ### Write KDI format
+          output_dir = "#{$basedir}/#{@options[:output_directory]}"
+          filename = "checkmarx_sast_kdi_#{project_id}.json"
+          kdi_upload output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, @retries, @kdi_version
+          print_good "\n"
+        end
+        kdi_connector_kickoff @kenna_connector_id, @kenna_api_host, @kenna_api_key
+      end
+
+      private
+
+      def initialze_options
+        @username = @options[:checkmarx_sast_user]
+        @password = @options[:checkmarx_sast_password]
+        @grant_type = @options[:grant_type]
+        @scope = @options[:scope]
+        @client_id = @options[:client_id]
+        @client_secret = @options[:client_secret]
+        @checkmarx_sast_url = if @options[:checkmarx_sast_console_port]
+                                "#{@options[:checkmarx_sast_console]}:#{@options[:checkmarx_sast_console_port]}"
+                              else
+                                @options[:checkmarx_sast_console]
+                              end
+        @kenna_api_host = @options[:kenna_api_host]
+        @kenna_api_key = @options[:kenna_api_key]
+        @kenna_connector_id = @options[:kenna_connector_id]
+        @retries = 3
+        @kdi_version = 2
+      end
+
+      # method to format date
+      def formatted_date(detection_date)
+        DateTime.strptime(detection_date, "%m/%d/%Y %k:%M:%S %p").strftime("%Y-%m-%d-%H:%M:%S")
+      end
+
+      # method to return pathnode information
+      def fetch_pathnode_info(path_node, additional_field)
+        pathnode_info = path_node.fetch(additional_field) if path_node.instance_of?(Hash)
+        pathnode_info = path_node[0].fetch(additional_field) if path_node.instance_of?(Array)
+        pathnode_info
+      end
+
+      def fetch_snippet(path_node)
+        snippet = fetch_pathnode_info(path_node, "Snippet")
+        snippet["Line"]["Code"].strip!
+        snippet
+      end
+    end
+  end
+end

--- a/tasks/connectors/checkmarx_sast/lib/checkmarx_sast_helper.rb
+++ b/tasks/connectors/checkmarx_sast/lib/checkmarx_sast_helper.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Kenna
+  module Toolkit
+    module CheckmarxSastHelper
+      attr_reader :username, :password, :grant_type, :scope, :checkmarx_sast_url, :client_id, :client_secret
+
+      # Method for generating token using username & pwd, client ID and secret
+      def request_checkmarx_sast_token
+        print_debug "Getting Auth Token"
+        checkmarx_sast_auth_api_url = "https://#{checkmarx_sast_url}/cxrestapi/auth/identity/connect/token"
+        # Retrieve an OAuth access token to be used against Checkmarx SAST API"
+        headers = { "content-type" => "application/x-www-form-urlencoded" }
+        payload = {
+          grant_type: grant_type,
+          scope: scope,
+          username: username,
+          password: password,
+          client_id: client_id,
+          client_secret: client_secret
+        }
+
+        begin
+          auth_response = http_post(checkmarx_sast_auth_api_url, headers, payload)
+          return unless auth_response
+
+          token = JSON.parse(auth_response)["access_token"]
+          print_debug token.to_s
+          token
+        rescue JSON::ParserError
+          print_error "Unable to process Auth Token response!"
+        rescue StandardError => e
+          print_error "Failed to retrieve Auth Token #{e.message}"
+        end
+      end
+
+      # method to get all projects using user credentials
+      def fetch_checkmarx_sast_projects(token)
+        checkmarx_sast_projects_api_url = "https://#{checkmarx_sast_url}/cxrestapi/projects"
+        headers = bearer_token_headers(token)
+        auth_response = http_get(checkmarx_sast_projects_api_url, headers)
+        return nil unless auth_response
+
+        begin
+          project_results = JSON.parse(auth_response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process Projects response!"
+        end
+        project_results
+      end
+
+      # method to fetch all scans of each project
+      def fetch_all_scans_of_project(token, project_id)
+        print_good "Getting All Scans of Project ID: #{project_id} \n"
+        checkmarx_sast_scans_api_url = "https://#{checkmarx_sast_url}/cxrestapi/sast/scans?last=1&scanStatus=Finished&projectId=#{project_id}"
+        headers = bearer_token_headers(token)
+        auth_response = http_get(checkmarx_sast_scans_api_url, headers)
+        return nil unless auth_response
+
+        begin
+          scan_results = JSON.parse(auth_response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process scans response!"
+        end
+        scan_results
+      end
+
+      def generate_report_id_from_scan(token, scan_id)
+        sast_report_generation_api_url = "https://#{checkmarx_sast_url}/cxrestapi/reports/sastScan"
+        headers = bearer_token_headers(token)
+        payload = {
+          ScanId: scan_id,
+          reportType: "XML"
+        }
+        auth_response = http_post(sast_report_generation_api_url, headers, payload)
+        return nil unless auth_response
+
+        begin
+          report = JSON.parse(auth_response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process report generation!"
+        end
+        report["reportId"]
+      end
+
+      def fetch_scan_reports(token, report_id)
+        sast_scan_reports_api_url = "https://#{checkmarx_sast_url}/cxrestapi/reports/sastScan/#{report_id}"
+        headers = bearer_token_headers(token)
+        auth_response = http_get(sast_scan_reports_api_url, headers)
+        return nil unless auth_response
+
+        begin
+          report = Hash.from_xml(auth_response.body)
+        rescue JSON::ParserError
+          print_error "Unable to process scan reports!"
+        end
+        report
+      end
+
+      private
+
+      def bearer_token_headers(token)
+        {
+          "Content-Type" => "application/json",
+          "accept" => "application/json",
+          "Authorization" => "Bearer #{token}"
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Running Checkmarx SAST task

This toolkit brings in data from Checkmarx SAST (https://partners9x.checkmarx.net/cxrestapi/)

To run this task you need the following information from Checkmarx SAST:

1. Username
2. Password
3. Client ID
4. Client Secret
5. grant_type
6. scope (optional)

## This Task will use the Checkmarx SAST API to

- Get a list of Projects currently present in the user's Checkmarx SAST account.
- Get a list of Scans in the user's Checkmarx SAST account associated with each Project.
- Generate Report Id on each scan.
- Get a list of scan reports using newly generated above report id.
- Output a json file in the Kenna Data Importer (KDI) format.
- Post the file to Kenna if API Key and Connector ID are provided