### PR TITLE
GitHub Dependabot Fixes

### DIFF
--- a/tasks/connectors/github_dependabot/github_dependabot.rb
+++ b/tasks/connectors/github_dependabot/github_dependabot.rb
@@ -64,6 +64,7 @@ module Kenna
 
         kdi_batch_upload(@batch_size, @output_directory, "github_dependabot_kdi.json", @kenna_connector_id, @kenna_api_host, @kenna_api_key, @skip_autoclose, @retries, @kdi_version) do |batch|
           client.repositories.each do |repo_name|
+            print_good "Processing repository #{@github_organization_name}/#{repo_name}."
             client.vulnerabilities(repo_name).each do |alert|
               batch.append do
                 process_alert(repo_name, alert)

--- a/tasks/connectors/github_dependabot/lib/github_dependabot_client.rb
+++ b/tasks/connectors/github_dependabot/lib/github_dependabot_client.rb
@@ -25,6 +25,8 @@ module Kenna
             response_hash = JSON.parse(response)
             raise ApiError, "Unable to retrieve data. GitHub GraphQL API returned the following errors:\n\n#{build_api_errors_string(response_hash['errors'])}" if response_hash["errors"]
 
+            raise ApiError, "GitHub GraphQL API unrecognized owner. Check github_organization_name parameter is a valid user or organization." unless response_hash.dig("data", "repositoryOwner")
+
             raise ApiError, "GitHub GraphQL API unrecognized response format." unless response_hash.dig("data", "repositoryOwner", "repositories", "nodes")
 
             response_hash["data"]["repositoryOwner"]["repositories"]["nodes"].map { |node| node["name"] }.each(&block)
@@ -64,7 +66,7 @@ module Kenna
         def repositories_query
           "query($organization_name: String!, $end_cursor: String, $page_size: Int!) {
             repositoryOwner(login: $organization_name) {
-              repositories(first: $page_size, after: $end_cursor) {
+              repositories(first: $page_size, after: $end_cursor, affiliations: OWNER) {
                 nodes {
                   name
                 }


### PR DESCRIPTION
Fixed error when retrieving alerts from a repo present in the organization but not owned by it.
Enhance error message when input owner name is wrong but token exists.
Added log for each processed repository