### PR TITLE
Sysdig asset_type changes

### DIFF
--- a/tasks/connectors/sysdig/lib/runtime_mapper.rb
+++ b/tasks/connectors/sysdig/lib/runtime_mapper.rb
@@ -8,8 +8,7 @@ module Kenna
       class RuntimeMapper < Mapper
         def extract_asset
           asset = {
-            "asset_type" => "container",
-            "container_id" => scan_data["hostId"],
+            "external_id" => scan_data["hostId"],
             "hostname" => scan_data["hostname"],
             "mac_address" => scan_data["macAddress"],
             "os" => scan_data["operatingSystem"],


### PR DESCRIPTION
Changed asset_type => "container" to only an external_id because the vendor says they are not always containers.