### PR TITLE
Add verbosity to API exception logging to help clients/support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -331,7 +331,7 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Layout/SpaceAroundMethodCallOperator:
-  Enabled: true  
+  Enabled: true
 
 Lint/RaiseException:
   Enabled: true
@@ -383,8 +383,9 @@ Style/GlobalVars:
     - $basedir
     - $mapping_array
     - $assets
-    - $vuln_defs 
-    - $date_format_in 
+    - $vuln_defs
+    - $date_format_in
     - $map_locator
     - $skip_autoclose
     - $toolkit_debug
+    - $toolkit_running_local

--- a/initialize/object.rb
+++ b/initialize/object.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 $toolkit_debug = false
+$toolkit_running_local = true
 
 def debug?
   $toolkit_debug
+end
+
+def running_local?
+  $toolkit_running_local
 end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -12,7 +12,7 @@ module Kenna
             verify_ssl: verify_ssl
           )
         rescue RestClient::TooManyRequests => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -21,9 +21,9 @@ module Kenna
             retry
           end
         rescue RestClient::UnprocessableEntity => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::BadRequest => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::InternalServerError => e
           retries ||= 0
           if retries < max_retries
@@ -32,11 +32,11 @@ module Kenna
             puts "Retrying!"
             retry
           end
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::ServerBrokeConnection => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::ExceptionWithResponse => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -45,9 +45,9 @@ module Kenna
             retry
           end
         rescue RestClient::NotFound => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::Exception => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -56,7 +56,7 @@ module Kenna
             retry
           end
         rescue Errno::ECONNREFUSED => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -75,7 +75,7 @@ module Kenna
             verify_ssl: verify_ssl
           )
         rescue RestClient::TooManyRequests => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -84,11 +84,11 @@ module Kenna
             retry
           end
         rescue RestClient::UnprocessableEntity => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::BadRequest => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::InternalServerError => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -97,9 +97,9 @@ module Kenna
             retry
           end
         rescue RestClient::ServerBrokeConnection => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::ExceptionWithResponse => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -108,9 +108,9 @@ module Kenna
             retry
           end
         rescue RestClient::NotFound => e
-          puts "Exception! #{e}"
+          log_exception(e)
         rescue RestClient::Exception => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -119,7 +119,7 @@ module Kenna
             retry
           end
         rescue Errno::ECONNREFUSED => e
-          puts "Exception! #{e}"
+          log_exception(e)
           retries ||= 0
           if retries < max_retries
             retries += 1
@@ -127,6 +127,13 @@ module Kenna
             sleep(15)
             retry
           end
+        end
+
+        def log_exception(e)
+          puts "Exception! #{e}"
+          puts "#{e.response.request.method} #{e.response.request.url}"
+          puts "request payload: #{e.response.request.payload}" 
+          puts "server response: #{e.response.body}"
         end
       end
     end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -17,7 +17,7 @@ module Kenna
           if retries < max_retries
             retries += 1
             sleep(15)
-            puts "Retrying!"
+            print "Retrying!"
             retry
           end
         rescue RestClient::UnprocessableEntity => e
@@ -29,7 +29,7 @@ module Kenna
           if retries < max_retries
             retries += 1
             sleep(15)
-            puts "Retrying!"
+            print "Retrying!"
             retry
           end
           log_exception(e)
@@ -40,7 +40,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -52,7 +52,7 @@ module Kenna
           if retries < max_retries
             retries += 1
             sleep(15)
-            puts "Retrying!"
+            print "Retrying!"
             retry
           end
         rescue Errno::ECONNREFUSED => e
@@ -60,7 +60,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -79,7 +79,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -92,7 +92,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -103,7 +103,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -114,7 +114,7 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
@@ -123,17 +123,23 @@ module Kenna
           retries ||= 0
           if retries < max_retries
             retries += 1
-            puts "Retrying!"
+            print "Retrying!"
             sleep(15)
             retry
           end
         end
 
         def log_exception(error)
-          puts "Exception! #{error}"
-          puts "#{error.response.request.method} #{error.response.request.url}"
-          puts "request payload: #{error.response.request.payload}"
-          puts "server response: #{error.response.body}"
+          print_error "Exception! #{error}"
+          return unless log_request?
+
+          print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"
+          print_debug "Request Payload: #{error.response.request.payload}"
+          print_debug "Server Response: #{error.response.body}"
+        end
+
+        def log_request?
+          debug? && running_local?
         end
       end
     end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -132,7 +132,7 @@ module Kenna
         def log_exception(error)
           puts "Exception! #{error}"
           puts "#{error.response.request.method} #{error.response.request.url}"
-          puts "request payload: #{error.response.request.payload}" 
+          puts "request payload: #{error.response.request.payload}"
           puts "server response: #{error.response.body}"
         end
       end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -129,11 +129,11 @@ module Kenna
           end
         end
 
-        def log_exception(e)
-          puts "Exception! #{e}"
-          puts "#{e.response.request.method} #{e.response.request.url}"
-          puts "request payload: #{e.response.request.payload}" 
-          puts "server response: #{e.response.body}"
+        def log_exception(error)
+          puts "Exception! #{error}"
+          puts "#{error.response.request.method} #{error.response.request.url}"
+          puts "request payload: #{error.response.request.payload}" 
+          puts "server response: #{error.response.body}"
         end
       end
     end

--- a/tasks/base.rb
+++ b/tasks/base.rb
@@ -57,6 +57,7 @@ module Kenna
       def run(opts)
         # Set global debug. You can get its value calling debug? method globally
         $toolkit_debug = opts[:debug] == "true"
+        $toolkit_running_local = !running_hosted?
 
         # pull our required arguments out
         required_options = self.class.metadata[:options].select { |a| a[:required] }
@@ -110,7 +111,24 @@ module Kenna
 
         print_good ""
         print_good "Launching the #{self.class.metadata[:name]} task!"
+        print_good "Toolkit running hosted" if running_hosted?
         print_good ""
+      end
+
+      private
+
+      def running_hosted?
+        @running_hosted ||= aws_host_info.present?
+      end
+
+      def aws_host_info
+        RestClient::Request.execute(
+          method: :get,
+          url: "http://169.254.169.254/latest/metadata/",
+          timeout: 1
+        )
+      rescue StandardError
+        nil
       end
     end
   end


### PR DESCRIPTION
This change adds more details to logging about API call exceptions. This will help clients know whether the failures they see logged are in their scanner or Kenna.