### PR TITLE
Update Netsparker task ID

### DIFF
--- a/tasks/utilities/netsparker/netsparker.rb
+++ b/tasks/utilities/netsparker/netsparker.rb
@@ -5,8 +5,8 @@ module Kenna
     class DeprecatedNetsparker < Kenna::Toolkit::BaseTask
       def self.metadata
         {
-          id: "netsparker",
-          name: "Netsparker",
+          id: "netsparker_old",
+          name: "Netsparker Old",
           maintainers: %w[dbro jcran],
           references: [
             "https://www.netsparkercloud.com/docs/index#!/Websites/Websites_List"


### PR DESCRIPTION
This is a deprecated task, and had a duplicate task ID causing this process to run instead of the updated netsparker task in the connectors folder.