### PR TITLE
Fix include_duplicated param

### DIFF
--- a/tasks/connectors/bugcrowd/bugcrowd_task.rb
+++ b/tasks/connectors/bugcrowd/bugcrowd_task.rb
@@ -132,7 +132,7 @@ module Kenna
 
       def submissions_filter
         {
-          include_duplicated: @options[:include_duplicated],
+          include_duplicated: @options[:include_duplicated].nil? ? false : @options[:include_duplicated],
           severity: @options[:severity],
           state: @options[:state],
           source: @options[:source],


### PR DESCRIPTION
include_duplicated param was nil and in ruby acted as false but when passed as parameter to BugCrowd it output as "" and endpoint raised 400 Bad requested due to an expected boolean value in the param.