### PR TITLE
DV-160 Add option for adding ES vulnerabilities as findings

### DIFF
--- a/tasks/connectors/edgescan/README.md
+++ b/tasks/connectors/edgescan/README.md
@@ -32,6 +32,7 @@ These are some quick examples:
 | kenna_connector_id | true     | Kenna connnector ID                                                          | none                     |
 | kenna_api_host     | false    | Kenna API hostname                                                           | api.us.kennasecurity.com |
 | output_directory   | false    | The task will write JSON files here (path is relative to the base directory) | output/edgescan          |
+| create_findings    | false    | The task will create findings, instead of vulnerabilities                    | false                    |
 
 ## For devs
 

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -50,7 +50,12 @@ module Kenna
               type: "filename",
               required: false,
               default: "output/edgescan",
-              description: "The task will write JSON files here (path is relative to #{$basedir})" }
+              description: "The task will write JSON files here (path is relative to #{$basedir})" },
+            { name: "create_findings",
+              type: "boolean",
+              required: false,
+              default: false,
+              description: "The task will create findings, instead of vulnerabilities" }
           ]
         }
       end

--- a/tasks/connectors/edgescan/lib/edgescan_vulnerability.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_vulnerability.rb
@@ -35,6 +35,20 @@ module Kenna
           }
         end
 
+        def to_kenna_finding
+          {
+            "scanner_identifier" => data["definition_id"],
+            "scanner_type" => scanner_type,
+            "created_at" => data["created_at"],
+            "last_seen_at" => data["updated_at"],
+            "severity" => data["threat"] * 2,
+            "additional_fields" => {
+              "status" => data["status"],
+              "details" => details
+            }
+          }
+        end
+
         def to_corresponding_kenna_asset
           { "external_id" => external_asset_id, "tags" => asset.tags }
         end

--- a/tasks/connectors/edgescan/lib/kenna_api.rb
+++ b/tasks/connectors/edgescan/lib/kenna_api.rb
@@ -31,6 +31,13 @@ module Kenna
           end
         end
 
+        # Converts Edgescan vulnerabilities into Kenna findings and adds them into memory
+        def add_findings(edgescan_vulnerabilities)
+          edgescan_vulnerabilities.each do |vulnerability|
+            add_finding(vulnerability.external_asset_id, vulnerability.to_kenna_finding)
+          end
+        end
+
         # Converts Edgescan definitions into Kenna ones and adds them into memory
         def add_definitions(edgescan_definitions)
           edgescan_definitions.each do |edgescan_definition|
@@ -65,6 +72,11 @@ module Kenna
         # Adds Kenna vulnerability into memory
         def add_vulnerability(external_asset_id, kenna_vulnerability)
           create_kdi_asset_vuln({ "external_id" => external_asset_id }, kenna_vulnerability, "external_id")
+        end
+
+        # Adds Kenna finding into memory
+        def add_finding(external_asset_id, kenna_finding)
+          create_kdi_asset_finding({ "external_id" => external_asset_id }, kenna_finding, "external_id")
         end
 
         # Adds Kenna definition into memory


### PR DESCRIPTION
# Context

Edgescan Vulnerabilities are unable to be ingested as Findings in Kenna.

# Changes

Updated the Edgescan connector to be able to ingest Edegscan Vulnerabilities as Findings given the `create_findings` flag is provided.