### PR TITLE
SUP-871 - SUP-871-separate_issue_severity_variables

### DIFF
--- a/tasks/connectors/snyk_v2/snyk_v2.rb
+++ b/tasks/connectors/snyk_v2/snyk_v2.rb
@@ -149,7 +149,7 @@ module Kenna
             break
           end
 
-          issue_severity = { "high" => 6, "medium" => 4, "low" => 1 } # converter
+          issue_severity_mapping = { "high" => 6, "medium" => 4, "low" => 1 } # converter
           issue_json.each do |issue_obj|
             issue = issue_obj["issue"]
             project = issue_obj["project"]
@@ -184,7 +184,7 @@ module Kenna
             scanner_score = if issue.key?("cvssScore")
                               issue.fetch("cvssScore").to_i
                             else
-                              issue_severity.fetch(issue.fetch("severity"))
+                              issue_severity_mapping.fetch(issue.fetch("severity"))
                             end
 
             source = project.fetch("source") if issue.key?("source")


### PR DESCRIPTION
Reuse of a variable name was causing errors.

We first assign a hash to issue_severity to map named values to integers.
`issue_severity = { "high" => 6, "medium" => 4, "low" => 1 }`

Later, while looping over Snyk issue data we reassign that from the "severity" field:
`issue_severity = issue.fetch("severity") if issue.key?("severity")`

On the next loop when we try to use the mapping, it errors because you can't .fetch a string:
```
/opt/app/toolkit/tasks/connectors/snyk_v2/snyk_v2.rb:187:in `block in run': undefined method `fetch' for "high":String (NoMethodError)

                                            issue_severity.fetch(issue.fetch("severity"))
                                                          ^^^^^^

        from /opt/app/toolkit/tasks/connectors/snyk_v2/snyk_v2.rb:153:in `each'
        from /opt/app/toolkit/tasks/connectors/snyk_v2/snyk_v2.rb:153:in `run'
        from toolkit.rb:57:in `<main>'
```

To resolve this I renamed the variable where it is used as a mapping and left the other use unchanged. The new variable name makes it more clear how it's being used.