### PR TITLE
Set local environment to get rid of deprecation

### DIFF
--- a/.github/workflows/nativeruby.yml
+++ b/.github/workflows/nativeruby.yml
@@ -19,8 +19,10 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
+    - name: Config environment
+      run: bundle config set --local without 'development test'
     - name: Install dependencies
-      run: bundle install --without development test
+      run: bundle install
     - name:  Run Toolkit
       run : ruby toolkit.rb task=help
       


### PR DESCRIPTION
Problem: Native ruby Github action fails because one command is deprecated.
Solution: change command as per example in deprecation warning