### PR TITLE
Update Edgescan Connector

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     netrc (0.11.0)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -72,7 +74,7 @@ GEM
       pry (~> 0.13.0)
     public_suffix (4.0.7)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     regexp_parser (2.3.0)
     rest-client (2.1.0)
@@ -162,6 +164,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   activesupport

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -69,7 +69,11 @@ module Kenna
         edgescan_api.fetch_in_batches do |edgescan_assets, edgescan_definitions|
           edgescan_assets.each do |edgescan_asset|
             kenna_api.add_assets(edgescan_asset)
-            kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
+            if @options[:create_findings]
+              kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
+            else
+              kenna_api.add_findings(edgescan_asset.vulnerabilities)
+            end
           end
 
           kenna_api.add_definitions(edgescan_definitions)

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -55,7 +55,17 @@ module Kenna
               type: "boolean",
               required: false,
               default: false,
-              description: "The task will create findings, instead of vulnerabilities" }
+              description: "The task will create findings, instead of vulnerabilities" },
+            { name: "include_network_vulnerabilities",
+              type: "boolean",
+              required: false,
+              default: true,
+              description: "The task will include network layer vulnerabilities" },
+            { name: "include_application_vulnerabilities",
+              type: "boolean",
+              required: false,
+              default: true,
+              description: "The task will include application layer vulnerabilities" }
           ]
         }
       end

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -81,9 +81,9 @@ module Kenna
             kenna_api.add_assets(edgescan_asset)
             if @options[:include_network_vulnerabilities] || @options[:include_application_vulnerabilities]
               if @options[:create_findings]
-                kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
-              else
                 kenna_api.add_findings(edgescan_asset.vulnerabilities)
+              else
+                kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
               end
             end
           end

--- a/tasks/connectors/edgescan/edgescan.rb
+++ b/tasks/connectors/edgescan/edgescan.rb
@@ -79,10 +79,12 @@ module Kenna
         edgescan_api.fetch_in_batches do |edgescan_assets, edgescan_definitions|
           edgescan_assets.each do |edgescan_asset|
             kenna_api.add_assets(edgescan_asset)
-            if @options[:create_findings]
-              kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
-            else
-              kenna_api.add_findings(edgescan_asset.vulnerabilities)
+            if @options[:include_network_vulnerabilities] || @options[:include_application_vulnerabilities]
+              if @options[:create_findings]
+                kenna_api.add_vulnerabilities(edgescan_asset.vulnerabilities)
+              else
+                kenna_api.add_findings(edgescan_asset.vulnerabilities)
+              end
             end
           end
 

--- a/tasks/connectors/edgescan/lib/edgescan_api.rb
+++ b/tasks/connectors/edgescan/lib/edgescan_api.rb
@@ -10,6 +10,8 @@ module Kenna
           @edgescan_token = options[:edgescan_token]
           @page_size = options[:edgescan_page_size].to_i
           @api_host = options[:edgescan_api_host]
+          @include_application_vulnerabilities = options[:include_application_vulnerabilities]
+          @include_network_vulnerabilities = options[:include_network_vulnerabilities]
         end
 
         # Fetches Edgescan assets and vulnerabilities in batches. Yields each batch.
@@ -49,7 +51,7 @@ module Kenna
         end
 
         def fetch_vulnerabilities(asset_ids)
-          query("vulnerabilities", { detail_level: "high", c: { asset_id_in: asset_ids.join(","), status: "open" } })
+          query("vulnerabilities", { detail_level: "high", c: { asset_id_in: asset_ids.join(","), status: "open" }.merge(layer_query_parameters) })
             .group_by { |vulnerability| vulnerability["asset_id"] }
         end
 
@@ -73,6 +75,18 @@ module Kenna
           return "http://localhost:3000" if ENV["EDGESCAN_ENVIRONMENT"] == "local"
 
           "https://#{@api_host}"
+        end
+
+        # Application vulnerabilities are on layer 7
+        # Network vulnerabilities are on every other layer
+        def layer_query_parameters
+          if @include_application_vulnerabilities && @include_network_vulnerabilities
+            {}
+          elsif @include_application_vulnerabilities
+            { layer_in: 7 }
+          else
+            { layer_not_in: 7 }
+          end
         end
       end
     end


### PR DESCRIPTION
# Context

Clients require the ability to import vulnerabilities based on layer type, `application` and `network`.
Bug also found when attempting to create Kenna findings.

# Changes

- Added 2 flags `include_network_vulnerabilities`, and `include_application_vulnerabilities` to allow the separation of vulnerabilities when importing. Both set to `true` by default.
- Fixed bug where Kenna findings were not being created when `create_findings` flag was set to `true`.