### PR TITLE
Convert quotes because doubles don't play nice w/ our queries

### DIFF
--- a/tasks/connectors/veracode_asset_vulns/readme.md
+++ b/tasks/connectors/veracode_asset_vulns/readme.md
@@ -10,6 +10,7 @@ To run this task you need the following information from Veracode:
 The data is batched by Application before being sent to Kenna. 
 
 1. Pull a list of applications (https://help.veracode.com/r/c_apps_intro)
+    - to work with Kenna data queries, double quotes in application names are converted to single quotes before being uploaded to Kenna
 1. Pull a list of assets and vulns for each application (https://help.veracode.com/r/c_findings_v2_intro)
 1. Prepare differential of assets from Kenna that are no longer being reported from Veracode for auto-closures.
 1. Submit JSON file for each application to Kenna

--- a/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
+++ b/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
@@ -99,7 +99,7 @@ module Kenna
 
         app_list.each do |application|
           guid = application.fetch("guid")
-          appname = application.fetch("name")
+          appname = application.fetch("name").gsub('"', "'")
           tags = application.fetch("tags")
           owner = application.fetch("owner")
           client.issues(guid, appname, tags, owner, page_size, veracode_scan_types)

--- a/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
+++ b/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb
@@ -99,7 +99,7 @@ module Kenna
 
         app_list.each do |application|
           guid = application.fetch("guid")
-          appname = application.fetch("name").gsub('"', "'")
+          appname = application.fetch("name").tr('"', "'")
           tags = application.fetch("tags")
           owner = application.fetch("owner")
           client.issues(guid, appname, tags, owner, page_size, veracode_scan_types)

--- a/tasks/connectors/veracode_findings/readme.md
+++ b/tasks/connectors/veracode_findings/readme.md
@@ -10,6 +10,7 @@ To run this task you need the following information from Microsoft:
 The data is batched by Application before being sent to Kenna. 
 
 1. Pull a list of applications (https://help.veracode.com/r/c_apps_intro)
+    - to work with Kenna data queries, double quotes in application names are converted to single quotes before being uploaded to Kenna
 1. Pull a list of findings for each application and submit to Kenna (https://help.veracode.com/r/c_findings_v2_intro)
 
 

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -74,7 +74,7 @@ module Kenna
 
         app_list.each do |application|
           guid = application.fetch("guid")
-          appname = application.fetch("name").gsub('"', "'")
+          appname = application.fetch("name").tr('"', "'")
           tags = application.fetch("tags")
           client.issues(guid, appname, tags, page_size)
         end

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -74,7 +74,7 @@ module Kenna
 
         app_list.each do |application|
           guid = application.fetch("guid")
-          appname = application.fetch("name")
+          appname = application.fetch("name").gsub('"', "'")
           tags = application.fetch("tags")
           client.issues(guid, appname, tags, page_size)
         end


### PR DESCRIPTION
**Problem**
Clients whose Veracode applications have double quotes in the name are seeing those tasks fail. We put those terms within another set of double quotes and this messes up tokenization of search terms.  This has long been an issue in Kenna UI and is unlikely to be solved soon.

**Solution**
Most clients work around this by using single quotes in the field values when double would otherwise be used. This change converts app names to single quotes after the initial pull of application data. This should not change the data in any other way since we always pull further data from Veracode using the apps Id instead of name.