### PR TITLE
Add info about how to upload to local api host

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ Please send all toolkit feature requests to kenna.toolkit.list@cisco.com.
 
 You can find connector development documentation in the project [Wiki](https://github.com/KennaSecurity/toolkit/wiki/Toolkit-Documentation)
 
+## QA
+If you wish to upload the /output folder to your local development environment, run:
+
+`bundle exec ruby toolkit.rb task=your-task kenna_api_host=your-local-api-host`
+
+Prerequisites: version of ruby that is specified in `.ruby-version`
+
 ## CONTRIBUTORS
 
 - @kenna-bmcdevitt (api client)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you wish to upload the /output folder to your local development environment, 
 
 `bundle exec ruby toolkit.rb task=your-task kenna_api_host=your-local-api-host`
 
-Prerequisites: version of ruby that is specified in `.ruby-version`
+Prerequisites: API token generated in UI, version of ruby that is specified in `.ruby-version`
 
 ## CONTRIBUTORS
 


### PR DESCRIPTION
## Problem
QAs upload files to production if they want to see the output in UI.

## Solution
Add a README section about how to run a task so that the local api host can accept toolkit's requests.