### PR TITLE
Fix: guard to allow to execute without kenna api

### DIFF
--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -372,6 +372,7 @@ module Kenna
         end
 
         def find_missing_kenna_assets(application)
+          return print "Warning: not connected to Kenna, cannot find missing assets." unless @kenna_api_host && @kenna_api_key && @kenna_connector_id
           # encoding help
           # enc_open_paren = "%28"
           # enc_close_paren = "%29"

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -373,6 +373,7 @@ module Kenna
 
         def find_missing_kenna_assets(application)
           return print "Warning: not connected to Kenna, cannot find missing assets." unless @kenna_api_host && @kenna_api_key && @kenna_connector_id
+
           # encoding help
           # enc_open_paren = "%28"
           # enc_close_paren = "%29"


### PR DESCRIPTION
That pr fixes a issue when trying to run a specific Veracode task without kenna api

Before:
![Screen Shot 2022-08-01 at 13 00 09](https://user-images.githubusercontent.com/105377901/182190742-d8d4b1a4-df0e-48d5-ab7c-991459ccaa90.png)

Change:
![Screen Shot 2022-08-01 at 13 00 37](https://user-images.githubusercontent.com/105377901/182190824-9caebdc7-b0fb-49a9-93d7-6ede493a5d15.png)

