### PR TITLE
Fix illegal quoting for csv2kdi with liberal_parsing parameter

### DIFF
--- a/tasks/utilities/csv2kdi/csv2kdi.rb
+++ b/tasks/utilities/csv2kdi/csv2kdi.rb
@@ -127,7 +127,8 @@ module Kenna
         $mapping_array = []
         $date_format_in = ""
 
-        CSV.parse(File.open("#{$basedir}/#{@input_directory}/#{@meta_file}", "r:iso-8859-1:utf-8", &:read), headers: @has_header.eql?("true") ? true : false) do |row|
+        CSV.parse(File.open("#{$basedir}/#{@input_directory}/#{@meta_file}", "r:iso-8859-1:utf-8", &:read),
+                  headers: @has_header.eql?("true") ? true : false, liberal_parsing: true) do |row|
           $mapping_array << Array[row[0], row[1]]
           $mapping_array.compact
         end
@@ -265,7 +266,8 @@ module Kenna
           puts "Ending processing of pre-check request"
           return
         end
-        CSV.parse(File.open("#{$basedir}/#{@input_directory}/#{@csv_in}", "r:bom|utf-8", &:read), headers: @has_header) do |row|
+        CSV.parse(File.open("#{$basedir}/#{@input_directory}/#{@csv_in}", "r:bom|utf-8", &:read),
+                  headers: @has_header, liberal_parsing: true) do |row|
           ##################
           #  CSV MAPPINGS  #
           ##################


### PR DESCRIPTION
Try to fix the error "illegal quoting.

Try №1
with `liberal_parsing: true`

<img width="537" alt="Screenshot 2022-08-02 at 12 16 54" src="https://user-images.githubusercontent.com/101565985/182343572-d1b64087-1458-4664-b58d-123743343eb7.png">