### PR TITLE
retry 422, treat success field as string

### DIFF
--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -152,12 +152,11 @@ module Kenna
           )
 
           query_response_json = JSON.parse(query_response.body)
-          if query_response_json.fetch("success")=="true"
-            print_good "Success!"
-            File.delete(filepath) unless debug
-          else
-            raise StandardError.new("File upload failed. kenna response: #{query_response_json}")
-          end
+          raise StandardError "File upload failed. kenna response: #{query_response_json}" unless query_response_json.fetch("success") == "true"
+          
+          print_good "Success!"
+          File.delete(filepath) unless debug
+
 
           running = true
 

--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -152,9 +152,11 @@ module Kenna
           )
 
           query_response_json = JSON.parse(query_response.body)
-          if query_response_json.fetch("success")
+          if query_response_json.fetch("success")=="true"
             print_good "Success!"
             File.delete(filepath) unless debug
+          else
+            raise StandardError.new("File upload failed. kenna response: #{query_response_json}")
           end
 
           running = true
@@ -191,13 +193,11 @@ module Kenna
             print_error "Max retries hit, failing with... #{e}"
             return
           end
-        rescue RestClient::UnprocessableEntity => e
-          print_error "Unprocessable Entity: #{e.message}..."
         rescue RestClient::BadRequest => e
           print_error "Bad Request: #{e.message}... #{e}"
         rescue RestClient::Unauthorized => e
           print_error "Unauthorized: #{e.message}... #{e}"
-        rescue RestClient::Exception, StandardError => e
+        rescue RestClient::Exception, RestClient::UnprocessableEntity, StandardError => e
           print_error "Unknown Exception: #{e}"
           puts e.backtrace
           print_error "Are you sure you provided a valid connector id?"
@@ -272,13 +272,11 @@ module Kenna
           connector_run_status_json = JSON.parse(connector_run_status_response)
         rescue RestClient::Exceptions::OpenTimeout => e
           print_error "Timeout: #{e.message}..."
-        rescue RestClient::UnprocessableEntity => e
-          print_error "Unprocessable Entity: #{e.message}..."
         rescue RestClient::BadRequest => e
           print_error "Bad Request: #{e.message}... #{e}"
         rescue RestClient::Unauthorized => e
           print_error "Unauthorized: #{e.message}... #{e}"
-        rescue RestClient::Exception, StandardError => e
+        rescue RestClient::Exception, RestClient::UnprocessableEntity, StandardError => e
           print_error "Unknown Exception: #{e}"
           print_error "Are you sure you provided a valid connector id?"
 

--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -272,11 +272,13 @@ module Kenna
           connector_run_status_json = JSON.parse(connector_run_status_response)
         rescue RestClient::Exceptions::OpenTimeout => e
           print_error "Timeout: #{e.message}..."
+        rescue RestClient::UnprocessableEntity => e
+          print_error "Unprocessable Entity: #{e.message}..."
         rescue RestClient::BadRequest => e
           print_error "Bad Request: #{e.message}... #{e}"
         rescue RestClient::Unauthorized => e
           print_error "Unauthorized: #{e.message}... #{e}"
-        rescue RestClient::Exception, RestClient::UnprocessableEntity, StandardError => e
+        rescue RestClient::Exception, StandardError => e
           print_error "Unknown Exception: #{e}"
           print_error "Are you sure you provided a valid connector id?"
 

--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -153,11 +153,9 @@ module Kenna
 
           query_response_json = JSON.parse(query_response.body)
           raise StandardError "File upload failed. kenna response: #{query_response_json}" unless query_response_json.fetch("success") == "true"
-          
+
           print_good "Success!"
           File.delete(filepath) unless debug
-
-
           running = true
 
           if run_now


### PR DESCRIPTION
## SUP-969

# Problem
On the connector file upload endpoint Kenna returns a 422 in a very generic failure scenario when the file could not be persisted in Kenna. This can be a sporadic problem, so we should not immediately fail toolkit run attempts when this happens..

Another failure saw errors when we try to process a seeming empty response from Kenna. The current response processing doesn't correctly check for success in the response so some failures slip by

# Solution
-add UnprocessableEntity to a rescue statement with retries.
-check "success" field assuming it's string value
-treat lack of "success":"true" in response as a generic failure (which does retries)