### PR TITLE
SUP-980-sentinel_fix_params_and_remove_api_check_step

### DIFF
--- a/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
@@ -17,13 +17,6 @@ module Kenna
           @page_size = page_size
         end
 
-        def api_key_valid?
-          get("/", retries: 0)
-          true
-        rescue Error
-          false
-        end
-
         def vulns(filters = {}, &)
           query = {
             "display_description" => "custom",

--- a/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
@@ -77,8 +77,8 @@ module Kenna
           retries = options.delete(:retries) { |_k| 5 }
 
           url = "#{BASE_PATH}#{path}"
-          params = { key: @api_key, format: :json }.merge(options)
-          response = Kenna::Toolkit::Helpers::Http.http_get(url, { params: }, retries)
+          params = { key: @api_key, accept: 'application/json' }.merge({params: options})
+          response = Kenna::Toolkit::Helpers::Http.http_get(url, params, retries)
 
           raise Error unless response
 

--- a/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
@@ -77,7 +77,7 @@ module Kenna
           retries = options.delete(:retries) { |_k| 5 }
 
           url = "#{BASE_PATH}#{path}"
-          params = { key: @api_key, accept: 'application/json' }.merge({params: options})
+          params = { key: @api_key, accept: "application/json" }.merge({ params: options })
           response = Kenna::Toolkit::Helpers::Http.http_get(url, params, retries)
 
           raise Error unless response

--- a/tasks/connectors/ntt_sentinel_dynamic/ntt_sentinel_dynamic.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/ntt_sentinel_dynamic.rb
@@ -92,7 +92,6 @@ module Kenna
           mapper = Kenna::Toolkit::NTTSentinelDynamic::Mapper.new(scoring_system)
 
           client = Kenna::Toolkit::NTTSentinelDynamic::ApiClient.new(api_key: key, page_size:)
-          fail_task "The Whitehat API does not accept the provided API key." unless client.api_key_valid?
 
           filter = {}
           filter[:query_severity] = query_severity


### PR DESCRIPTION
# SUP-980

## Problem
Client was seeing 401 unauthorized errors using the Whitehat/Sentinel toolkit task despite providing valid api token. Support discovered that the params provided to RestClient were not in the right form. After resolving that I ran into two other problems:
1. The task tries to "validate" the api token using an endpoint that doesn't seem to be documented and was returning 404
2. Accept header was not passed in correctly, so we were getting data back in unexpected XML

## Solution
1. fix params format to be {header1: value1, header2: value2, params:{urlparam1: "value1", urlparam2: "value2"}}
2. remove invalid validation call step - we can expect a 401 in later calls if there's a problem with the token
  - see: `https://apidocs.whitehatsec.com/whs/reference/`
  - was using a GET to '/' endpoint
3. specify accept: header explicitly