### PR TITLE
Fix simular files for expanse_issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
     minitest (5.16.2)
     multi_xml (0.6.0)
     netrc (0.11.0)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -163,6 +165,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/tasks/connectors/digital_footprint/expanse_issues/lib/expanse_issues_mapper.rb
+++ b/tasks/connectors/digital_footprint/expanse_issues/lib/expanse_issues_mapper.rb
@@ -90,11 +90,11 @@ module Kenna
                 create_kdi_vuln_def(cvd)
               end
             end
-            if @assets.size.positive?
-              filename = "expanse_kdi_#{bu}.json"
-              kdi_upload @output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, 3, 2
-            end
           end
+          return unless @assets.size.positive?
+
+          filename = "expanse_kdi_#{business_units.count}_business_units.json"
+          kdi_upload @output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, 3, 2
         end
 
         def map_issue_priority(sev_word)

--- a/tasks/connectors/digital_footprint/expanse_issues/lib/expanse_issues_mapper.rb
+++ b/tasks/connectors/digital_footprint/expanse_issues/lib/expanse_issues_mapper.rb
@@ -42,6 +42,8 @@ module Kenna
         end
 
         def create_kdi_from_issues(max_per_page, issue_types, priorities, tags, dfm, lookback)
+          offset = 1
+
           ###
           ### Get the list of business units
           ###
@@ -93,8 +95,12 @@ module Kenna
           end
           return unless @assets.size.positive?
 
-          filename = "expanse_kdi_#{business_units.count}_business_units.json"
+          filename = "expanse_kdi_#{business_units.count}_business_units_#{offset}.json"
           kdi_upload @output_dir, filename, @kenna_connector_id, @kenna_api_host, @kenna_api_key, false, 3, 2
+
+          # rubocop:disable Lint/UselessAssignment
+          offset += 1
+          # rubocop:enable Lint/UselessAssignment
         end
 
         def map_issue_priority(sev_word)


### PR DESCRIPTION
[CON-1551](https://kennasecurity.atlassian.net/browse/CON-1551)

1) Run the task with the optional parameter issue_types=MissingCacheControlHeader

Expected
The run should fetch only vulns related to the issue_type and create only one file

Actual
The run creates 4 files with same data
