### PR TITLE
Only print response if it's a RestClient error

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -133,9 +133,11 @@ module Kenna
           print_error "Exception! #{error}"
           return unless log_request?
 
-          print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"
-          print_debug "Request Payload: #{error.response.request.payload}"
-          print_debug "Server Response: #{error.response.body}"
+          if error.is_a?(RestClient::Exception)
+            print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"
+            print_debug "Request Payload: #{error.response.request.payload}"
+            print_debug "Server Response: #{error.response.body}"
+          end
         end
 
         def log_request?

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -131,13 +131,11 @@ module Kenna
 
         def log_exception(error)
           print_error "Exception! #{error}"
-          return unless log_request?
+          return unless log_request? && error.is_a?(RestClient::Exception)
 
-          if error.is_a?(RestClient::Exception)
-            print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"
-            print_debug "Request Payload: #{error.response.request.payload}"
-            print_debug "Server Response: #{error.response.body}"
-          end
+          print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"
+          print_debug "Request Payload: #{error.response.request.payload}"
+          print_debug "Server Response: #{error.response.body}"
         end
 
         def log_request?


### PR DESCRIPTION
## SUP-988

## Problem
A client hit an error running the toolkit when some api calls returned an Errno::ECONNREFUSED exception that we are not handling correctly:
```
[!] (20220901194247) Exception! Failed to open TCP connection to aqua.prod.us-west-2.aws.fico.com:443 (Connection refused - connect(2) for 52.89.54.93:443)
/opt/app/toolkit/lib/http.rb:136:in `log_exception': [1mundefined method `response' for #<Errno::ECONNREFUSED: Failed to open TCP connection to aqua.prod.us-west-2.aws.fico.com:443 (Connection refused - connect(2) for 52.89.54.93:443)> ([1;4mNoMethodError[m[1m)[m

[1m          print_debug "#{error.response.request.method.upcase}: #{error.response.request.url}"[m
[1m                              ^^^^^^^^^[m
[1mDid you mean?  respond_to?[m
	from /opt/app/toolkit/lib/http.rb:59:in `rescue in http_get'
	from /opt/app/toolkit/lib/http.rb:7:in `http_get'
	from /opt/app/toolkit/tasks/connectors/aqua/lib/aqua_helper.rb:42:in `aqua_get_vuln'
	from /opt/app/toolkit/tasks/connectors/aqua/aqua.rb:167:in `run'
	from toolkit.rb:57:in `<main>'
/usr/local/lib/ruby/3.1.0/socket.rb:1214:in `__connect_nonblock': [1mFailed to open TCP connection to aqua.prod.us-west-2.aws.fico.com:443 (Connection refused - connect(2) for 52.89.54.93:443) ([1;4mErrno::ECONNREFUSED[m[1m)[m
	from /usr/local/lib/ruby/3.1.0/socket.rb:1214:in `connect_nonblock'
	from /usr/local/lib/ruby/3.1.0/socket.rb:56:in `connect_internal'
	from /usr/local/lib/ruby/3.1.0/socket.rb:137:in `connect'
	from /usr/local/lib/ruby/3.1.0/socket.rb:642:in `block in tcp'
	from /usr/local/lib/ruby/3.1.0/socket.rb:227:in `each'
	from /usr/local/lib/ruby/3.1.0/socket.rb:227:in `foreach'
	from /usr/local/lib/ruby/3.1.0/socket.rb:632:in `tcp'
```

## Solution
Every other use of this method is from RestClient exception handling and that's what these lines expect, so we add a check if the exception is that type before those lines.