### PR TITLE
account for nil tags with the Wiz toolkit

### DIFF
--- a/tasks/connectors/wiz/lib/vulns_mapper.rb
+++ b/tasks/connectors/wiz/lib/vulns_mapper.rb
@@ -21,7 +21,7 @@ module Kenna
             "hostname" => extract_hostname(vuln),
             "os" => (vuln["vulnerableAsset"]["operatingSystem"] if vuln["vulnerableAsset"]["type"] == "VIRTUAL_MACHINE"),
             "ip_address" => ((vuln["vulnerableAsset"]["ipAddresses"] || []).first if vuln["vulnerableAsset"]["type"] == "VIRTUAL_MACHINE"),
-            "tags" => extract_tags(vuln)
+            "tags" => (extract_tags(vuln) if vuln["vulnerableAsset"]["tags"].present?)
           }.compact
           asset["asset_type"] = "image" if asset["image_id"]
           asset


### PR DESCRIPTION
Summary

Kenna Support received a ticket about the Wiz toolkit failing due to this error
`/opt/app/toolkit/tasks/connectors/wiz/lib/vulns_mapper.rb:34:in `extract_tags': undefined method `map' for nil:NilClass (NoMethodError)`

After adding debug statements I found that some WIz vulnerableAsset objects have no tag info returned via the API.  I met with Wiz/SYSCO to discuss this and Wiz confirmed that in some rare cases, the payloads will have `nil` for the vulnerableAsset["tags"] field.  This change will force the toolkit to check for the existence of tags before it tries to extract_tags.

I tested the changes against my sandbox environment and valid KDI files were produced. After uploading the files they created valid asset/vuln records.  