### PR TITLE
Change `github_access_token` to `github_token`

### DIFF
--- a/tasks/connectors/github_dependabot/readme.md
+++ b/tasks/connectors/github_dependabot/readme.md
@@ -16,8 +16,8 @@ Start here to learn how to get personal access token:
 ## Complete list of Options:
 
 | Option                   | Required | Description                                                       | default |
-|--------------------------| -- |----------------------------------------------------------------------------| --- |
-| github_access_token      | true | Github access token                                                        | n/a |
+|--------------------------| -------- |-------------------------------------------------------------------| ------- |
+| github_token             | true | Github access token                                                        | n/a |
 | github_organization_name | true | Github organization name or user                                           | n/a |
 | github_page_size         | false | Number of records to bring back with each page request from GitHub. Maximum is 100. | 100 |
 | kenna_batch_size         | false | Maximum number of vulnerabilities to upload to Kenna in each batch.  | 500 |
@@ -31,4 +31,4 @@ Start here to learn how to get personal access token:
 
 For extracting Image vulnerability data:
 
-   toolkit:latest task=github_dependabot github_access_token=v954xxxxxx kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx
+   toolkit:latest task=github_dependabot github_token=v954xxxxxx github_organization_name=orgxxx kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx


### PR DESCRIPTION
Closes #439

### Problem

`github_access_token` does not seem to be the correct option for the [`github_dependabot`](https://github.com/KennaSecurity/toolkit/tree/c2ea5b06686a3838aaae9faa1eb8843f077d1527/tasks/connectors/github_dependabot) task.

### Solution

`github_token` seems to be the correct option.

Looking at the task, the actual name of the option is `github_token`:

https://github.com/KennaSecurity/toolkit/blob/c2ea5b06686a3838aaae9faa1eb8843f077d1527/tasks/connectors/github_dependabot/github_dependabot.rb#L83

Also, when using `github_access_token`, the action output shows this error:

```
docker.io/kennasecurity/toolkit:latest
Running: Kenna::Toolkit::GithubDependabot
[!] (…) Missing! github_token: Github Access Token
[!] (…) Required options missing, cowardly refusing to continue!
```

With `github_token`, the action succeeds.

### Miscellaneous

`github_organization_name` is also marked as a required option, yet it's not present in the README's example, so I added it.