### PR TITLE
Update Cobalt.io connector

### DIFF
--- a/tasks/connectors/cobaltio/cobaltio.rb
+++ b/tasks/connectors/cobaltio/cobaltio.rb
@@ -71,7 +71,7 @@ module Kenna
         print_debug "findings json = #{findings_json}"
         fail_task "Unable to retrieve findings, please check credentials" if findings_json.nil?
 
-        severity_map = { "high" => 7, "medium" => 5, "low" => 3 } # converter
+        severity_map = { "critical" => 9, "high" => 7, "medium" => 5, "low" => 3, "informational" => 1 } # converter
         state_map = { "need_fix" => "new", "wont_fix" => "risk_accepted", "valid_fix" => "resolved", "check_fix" => "in_progress", "carried_over" => "new" }
         status_map = { "need_fix" => "open", "wont_fix" => "closed", "valid_fix" => "closed", "check_fix" => "open", "carried_over" => "open" }
         findings_json.each do |finding_obj|

--- a/tasks/connectors/cobaltio/lib/cobaltio_helper.rb
+++ b/tasks/connectors/cobaltio/lib/cobaltio_helper.rb
@@ -7,7 +7,7 @@ module Kenna
 
       def cobalt_get_assets(api_token, org_token)
         print "Getting list of assets"
-        cobalt_assets_api = "https://api.cobalt.io/assets"
+        cobalt_assets_api = "https://api.cobalt.io/assets?limit=1000"
         headers = cobalt_get_req_headers(api_token, org_token)
 
         response = http_get(cobalt_assets_api, headers)
@@ -29,7 +29,7 @@ module Kenna
 
       def cobalt_get_findings(api_token, org_token)
         print "Getting list of findings"
-        cobalt_findings_api = "https://api.cobalt.io/findings"
+        cobalt_findings_api = "https://api.cobalt.io/findings?limit=1000"
         headers = cobalt_get_req_headers(api_token, org_token)
 
         response = http_get(cobalt_findings_api, headers)


### PR DESCRIPTION
Update the Cobalt.io connector/task in two ways:

1. Add support for "critical" and "informational" severity findings. Without this the connector/task would break if any finding has either of these severities.
2. Update the API requests to always fetch the maximum number of resources possible