### PR TITLE
Update readme.md

### DIFF
--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -17,7 +17,7 @@
 | [Aqua](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/aqua/README.md) | Pre-Release/Beta | Aqua |
 | [Armis](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/armis) | Pre_Release/Beta | Armis |
 | [AWS_guardduty](https://github.com/KennaSecurity/toolkit/blob/main/tasks/connectors/aws_guardduty/ReadME.md) | Pre-Release/Beta | Kenna |
-| [AWS_inspector](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/aws_inspector) | Pre-Release/Beta | Kenna |
+| [AWS_inspector v1](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/aws_inspector) | Pre-Release/Beta | Kenna |
 | [Bitsight](https://github.com/KennaSecurity/toolkit/blob/main/tasks/connectors/digital_footprint/bitsight/README.md) | Released | Kenna |
 | [Bugcrowd](https://github.com/KennaSecurity/toolkit/blob/main/tasks/connectors/bugcrowd/readme.md) | Pre-Release/Beta | Kenna |
 | [Burp](https://github.com/KennaSecurity/toolkit/blob/main/tasks/connectors/burp/readme.md) | Pre-Release/Beta | Kenna |


### PR DESCRIPTION
Adding clarification to AWS Inspector, is V1 support ONLY.