### PR TITLE
Lacework: v1 -> v2 API

### DIFF
--- a/.github/workflows/nativeruby.yml
+++ b/.github/workflows/nativeruby.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.1.2
     - name: Config environment
       run: bundle config set --local without 'development test'
     - name: Install dependencies

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ruby:3.1.2
 USER root
 
 # Update the base image.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If everything's working, lets move on to accessing the toolkit's functionality t
 
 In order to utilize the toolkit's functionality, you'll want to pass a 'task=[name of task]' variable. See below for all the possible task names!
 
-Calling A Specific Task WIth Docker:
+Calling A Specific Task With Docker:
 
     docker run -it --rm toolkit:latest task=example
 

--- a/lib/kdi/kdi_helpers.rb
+++ b/lib/kdi/kdi_helpers.rb
@@ -209,7 +209,7 @@ module Kenna
         return unless write_assets.present?
 
         write_file_stream(output_dir, filename, skip_autoclose, write_assets, @vuln_defs, version)
-        print_good "Output is available at: #{filename}"
+        print_good "Output is available at: #{output_dir}/#{filename}"
 
         ### Finish by uploading if we're all configured
         if kenna_connector_id && kenna_api_host && kenna_api_key
@@ -227,7 +227,7 @@ module Kenna
         ### Finish by uploading if we're all configured
         return if @uploaded_files.blank?
 
-        print_good "Attempting to run to Kenna Connector at #{@kenna_api_host}"
+        print_good "Attempting to run Kenna Connector at #{@kenna_api_host}"
         run_files_on_kenna_connector(kenna_connector_id, kenna_api_host, kenna_api_key, @uploaded_files)
       end
 

--- a/tasks/connectors/digital_footprint/bitsight/bitsight.rb
+++ b/tasks/connectors/digital_footprint/bitsight/bitsight.rb
@@ -91,7 +91,7 @@ module Kenna
         bitsight_findings_and_create_kdi(bitsight_create_benign_findings, benign_finding_grades, company_guids, fm, @options[:bitsight_lookback])
 
         ### Write KDI format
-        print_good "Attempting to run to Kenna Connector at #{@kenna_api_host}"
+        print_good "Attempting to run Kenna Connector at #{@kenna_api_host}"
         kdi_connector_kickoff(@kenna_connector_id, @kenna_api_host, @kenna_api_key)
       end
     end

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -81,7 +81,7 @@ module Kenna
         print_good "Pulling asset and vulnerability data from Lacework API"
         vulns_all = lacework_list_cves_v2(lacework_account, temp_api_token)
 
-        unless vulns_all && vulns_all.length > 0
+        unless vulns_all && !vulns_all.empty?
           print_error "Could not retrieve asset / vulnerability data from Lacework"
           return
         end

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -83,14 +83,14 @@ module Kenna
 
         vulns_by_host = {}
         vulns_all.each do |vuln|
-          key = [ vuln['machineTags']['Hostname'], vuln['mid'] ]
+          key = [vuln["machineTags"]["Hostname"], vuln["mid"]]
           vulns_by_host[key] ||= []
 
           hsh = {
             "scanner_identifier": vuln["vulnId"],
             "scanner_type": "Lacework",
-            "scanner_score": (vuln.dig('cveProps', 'metadata', 'NVD', 'CVSSv3', 'Score') || 0).to_i,
-            "last_seen_at": vuln['props']['last_updated_time'],
+            "scanner_score": (vuln.dig("cveProps", "metadata", "NVD", "CVSSv3", "Score") || 0).to_i,
+            "last_seen_at": vuln["props"]["last_updated_time"],
             "status": vuln["status"] == "Active" ? "open" : "closed",
             "vuln_def_name": vuln["vulnId"]
           }

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -9,14 +9,14 @@ module Kenna
       MAX_ATTEMPTS = 3
 
       def generate_temporary_lacework_api_token(account, api_key, api_secret)
-        uri = URI.parse("https://#{account}.lacework.net/api/v1/access/tokens")
+        uri = URI.parse("https://#{account}.lacework.net/api/v2/access/tokens")
 
         request = Net::HTTP::Post.new(uri)
         request.content_type = "application/json"
-        request["X-Lw-Uaks"] = api_secret.to_s
+        request["X-LW-UAKS"] = api_secret.to_s
         request.body = JSON.dump({
                                    "keyId" => api_key.to_s,
-                                   "expiryTime" => 9999
+                                   "expiryTime" => 86400
                                  })
 
         req_options = {
@@ -27,48 +27,94 @@ module Kenna
           http.request(request)
         end
 
-        if response.code != 200
+        if response.code != "201"
           print_debug response.message
           return nil
         end
 
-        JSON.parse(response.body)["data"].last["token"]
+        JSON.parse(response.body)["token"]
       end
 
-      def lacework_list_hosts(account, cve_id, temp_api_token)
-        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host/cveId/#{cve_id}?status=Active' -H 'Authorization: Bearer #{temp_api_token}'")
-        JSON.parse(raw)
-      end
+      def lacework_post(url:, body:, api_token:)
+        uri = URI.parse(url)
 
-      def lacework_list_cves(account, temp_api_token)
-        raw = call("curl -s 'https://#{account}.lacework.net/api/v1/external/vulnerabilities/host' -H 'Authorization: Bearer #{temp_api_token}'")
-        JSON.parse(raw)
-      end
+        request = Net::HTTP::Post.new(uri)
+        request.content_type = "application/json"
+        request["Authorization"] = "Bearer #{api_token}"
+        request.body = body
 
-      def call(cmd)
-        attempts = 0
-        loop do
-          attempts += 1
-          response = `#{cmd}`
-          status = $CHILD_STATUS
-          break response if status.success?
+        req_options = {
+          use_ssl: uri.scheme == "https"
+        }
 
-          warn "#{cmd} failed (attempt #{attempts})."
-          raise StandardError, "Retries exhausted for #{cmd}" if attempts == MAX_ATTEMPTS
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+          http.request(request)
         end
+
+        if response.code != "200"
+          print_debug response.message
+          return nil
+        end
+
+        hsh = JSON.parse(response.body)
+        data = hsh['data']
+
+        total_records = hsh.dig('paging', 'totalRows') || 0
+        print_good "Retrieved #{data.count} of #{total_records} records"
+
+        while url_next_page = hsh.dig('paging', 'urls', 'nextPage')
+          hsh = lacework_get(url: url_next_page, api_token: api_token)
+          data += (hsh['data'] || [])
+          print_good "Retrieved #{data.count} records"
+        end
+
+        print_good "Done!"
+
+        data
       end
 
-      def vulns_for(host)
-        host["packages"].map do |package|
+      def lacework_get(url:, api_token:)
+        uri = URI.parse(url)
+
+        request = Net::HTTP::Get.new(uri)
+        request.content_type = "application/json"
+        request["Authorization"] = "Bearer #{api_token}"
+
+        req_options = {
+          use_ssl: uri.scheme == "https"
+        }
+
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+          http.request(request)
+        end
+
+        if response.code != "200"
+          print_debug response.message
+          return nil
+        end
+
+        JSON.parse(response.body)
+      end
+
+      def lacework_list_cves_v2(account, temp_api_token)
+        # See: https://docs.lacework.com/api/v2/docs/#tag/Vulnerabilities/paths/~1api~1v2~1Vulnerabilities~1Hosts~1search/post
+
+        url = "https://#{account}.lacework.net/api/v2/Vulnerabilities/Hosts/search"
+
+        # Without the vulnId filter you get all of a host's packages even if they don't have vulns
+        request_body = %Q{
           {
-            "scanner_identifier": package["cve_link"].match(/CVE(.*)$/)[0],
-            "scanner_type": "Lacework",
-            "scanner_score": package["cvss_score"].to_i,
-            "last_seen_at": Time.now.utc,
-            "status": package["status"] == "Active" ? "open" : "closed",
-            "vuln_def_name": package["cve_link"].match(/CVE(.*)$/)[0]
+            "filters": [
+              {
+                "field": "vulnId",
+                "expression": "rlike",
+                "value": "CVE.*"
+              }
+            ]
           }
-        end
+        }
+        request_body = '{}'
+        lacework_post(url: url, body: request_body, api_token: temp_api_token)
       end
     end
   end

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -113,7 +113,6 @@ module Kenna
             ]
           }
         }
-        request_body = '{}'
         lacework_post(url: url, body: request_body, api_token: temp_api_token)
       end
     end

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -16,7 +16,7 @@ module Kenna
         request["X-LW-UAKS"] = api_secret.to_s
         request.body = JSON.dump({
                                    "keyId" => api_key.to_s,
-                                   "expiryTime" => 86400
+                                   "expiryTime" => 86_400
                                  })
 
         req_options = {
@@ -57,14 +57,14 @@ module Kenna
         end
 
         hsh = JSON.parse(response.body)
-        data = hsh['data']
+        data = hsh["data"]
 
-        total_records = hsh.dig('paging', 'totalRows') || 0
+        total_records = hsh.dig("paging", "totalRows") || 0
         print_good "Retrieved #{data.count} of #{total_records} records"
 
-        while url_next_page = hsh.dig('paging', 'urls', 'nextPage')
-          hsh = lacework_get(url: url_next_page, api_token: api_token)
-          data += (hsh['data'] || [])
+        while (url_next_page = hsh.dig("paging", "urls", "nextPage"))
+          hsh = lacework_get(url: url_next_page, api_token:)
+          data += (hsh["data"] || [])
           print_good "Retrieved #{data.count} records"
         end
 
@@ -102,7 +102,7 @@ module Kenna
         url = "https://#{account}.lacework.net/api/v2/Vulnerabilities/Hosts/search"
 
         # Without the vulnId filter you get all of a host's packages even if they don't have vulns
-        request_body = %Q{
+        request_body = %(
           {
             "filters": [
               {
@@ -112,8 +112,8 @@ module Kenna
               }
             ]
           }
-        }
-        lacework_post(url: url, body: request_body, api_token: temp_api_token)
+        )
+        lacework_post(url:, body: request_body, api_token: temp_api_token)
       end
     end
   end

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -52,11 +52,11 @@ module Kenna
         end
 
         if response.code == "204"
-          print_good "Lacework API returned HTTP code 204: no results found"
+          print_error "Lacework API returned HTTP code 204: no results found"
           return []
         elsif response.code != "200"
-          print_good "Lacework API returned HTTP code #{response.code}:"
-          print_good response.message
+          print_error "Lacework API returned HTTP code #{response.code}:"
+          print_error response.message
           return []
         end
 
@@ -95,8 +95,8 @@ module Kenna
         end
 
         if response.code != "200"
-          print_good "Lacework API returned HTTP code #{response.code}:"
-          print_good response.message
+          print_error "Lacework API returned HTTP code #{response.code}:"
+          print_error response.message
           return nil
         end
 

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -2,7 +2,6 @@
 
 require "net/http"
 require "uri"
-require 'pry'
 
 module Kenna
   module Toolkit
@@ -70,6 +69,7 @@ module Kenna
         while (url_next_page = hsh.dig("paging", "urls", "nextPage"))
           hsh = lacework_get(url: url_next_page, api_token:)
           return data if hsh.nil?
+
           data += (hsh["data"] || [])
           print_good "Retrieved #{data.count} records"
         end

--- a/tasks/connectors/ms_defender_atp/lib/ms_defender_atp_helper.rb
+++ b/tasks/connectors/ms_defender_atp/lib/ms_defender_atp_helper.rb
@@ -34,7 +34,7 @@ module Kenna
         ### Finish by uploading if we're all configured
         return unless kenna_connector_id && kenna_api_host && kenna_api_key
 
-        print_good "Attempting to run to Kenna Connector at #{kenna_api_host}"
+        print_good "Attempting to run Kenna Connector at #{kenna_api_host}"
         run_files_on_kenna_connector kenna_connector_id, kenna_api_host, kenna_api_key, @uploaded_files, max_retries
       end
 


### PR DESCRIPTION
Lacework's v1 API is deprecated and support for it will be shut off on 1/1/2023.

This PR changes the Lacework endpoints to v2 and makes any related changes necessary for everything to work.
