### PR TITLE
Lacework rate limits & retry custom wait

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "rest-client"
 gem "rexml", ">= 3.2.5"
 gem "sanitize"
 gem "tty-pager"
+gem "ruby-limiter"
 
 group :development, :test do
   gem "pry"

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -16,9 +16,9 @@ module Kenna
           log_exception(e)
           if retries < max_retries
             retries += 1
-            sleep_time=15
-            if e.response.headers.dig('RateLimit-Reset')
-              sleep_time=e.response.headers['RateLimit-Reset'].to_i + 1
+            sleep_time = 15
+            if e.response.headers.key?('RateLimit-Reset')
+              sleep_time = e.response.headers['RateLimit-Reset'].to_i + 1
               puts "RateLimit-Reset header provided. sleeping #{sleep_time}"
             end
             sleep(sleep_time)
@@ -80,9 +80,9 @@ module Kenna
           log_exception(e)
           if retries < max_retries
             retries += 1
-            sleep_time=15
-            if e.response.headers.dig('RateLimit-Reset')
-              sleep_time=e.response.headers['RateLimit-Reset'].to_i + 1
+            sleep_time = 15
+            if e.response.headers.key?('RateLimit-Reset')
+              sleep_time = e.response.headers['RateLimit-Reset'].to_i + 1
               puts "RateLimit-Reset header provided. sleeping #{sleep_time}"
             end
             print "Retrying!"

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -5,6 +5,7 @@ module Kenna
     module Helpers
       module Http
         def http_get(url, headers, max_retries = 5, verify_ssl = true)
+          retries ||= 0
           RestClient::Request.execute(
             method: :get,
             url:,
@@ -13,10 +14,14 @@ module Kenna
           )
         rescue RestClient::TooManyRequests => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
-            sleep(15)
+            sleep_time=15
+            if e.response.headers.dig('RateLimit-Reset')
+              sleep_time=e.response.headers['RateLimit-Reset'].to_i + 1
+              puts "RateLimit-Reset header provided. sleeping #{sleep_time}"
+            end
+            sleep(sleep_time)
             print "Retrying!"
             retry
           end
@@ -25,7 +30,6 @@ module Kenna
         rescue RestClient::BadRequest => e
           log_exception(e)
         rescue RestClient::InternalServerError => e
-          retries ||= 0
           if retries < max_retries
             retries += 1
             sleep(15)
@@ -37,7 +41,6 @@ module Kenna
           log_exception(e)
         rescue RestClient::ExceptionWithResponse => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"
@@ -48,7 +51,6 @@ module Kenna
           log_exception(e)
         rescue RestClient::Exception => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             sleep(15)
@@ -57,7 +59,6 @@ module Kenna
           end
         rescue Errno::ECONNREFUSED => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"
@@ -67,6 +68,7 @@ module Kenna
         end
 
         def http_post(url, headers, payload, max_retries = 5, verify_ssl = true)
+          retries ||= 0
           RestClient::Request.execute(
             method: :post,
             url:,
@@ -76,11 +78,15 @@ module Kenna
           )
         rescue RestClient::TooManyRequests => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
+            sleep_time=15
+            if e.response.headers.dig('RateLimit-Reset')
+              sleep_time=e.response.headers['RateLimit-Reset'].to_i + 1
+              puts "RateLimit-Reset header provided. sleeping #{sleep_time}"
+            end
             print "Retrying!"
-            sleep(15)
+            sleep(sleep_time)
             retry
           end
         rescue RestClient::UnprocessableEntity => e
@@ -89,7 +95,6 @@ module Kenna
           log_exception(e)
         rescue RestClient::InternalServerError => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"
@@ -100,7 +105,6 @@ module Kenna
           log_exception(e)
         rescue RestClient::ExceptionWithResponse => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"
@@ -111,7 +115,6 @@ module Kenna
           log_exception(e)
         rescue RestClient::Exception => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"
@@ -120,7 +123,6 @@ module Kenna
           end
         rescue Errno::ECONNREFUSED => e
           log_exception(e)
-          retries ||= 0
           if retries < max_retries
             retries += 1
             print "Retrying!"

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -64,6 +64,7 @@ module Kenna
       end
 
       def run(opts)
+        RestClient.log=STDOUT
         super
 
         lacework_account = @options[:lacework_account]
@@ -73,9 +74,9 @@ module Kenna
         @kenna_api_key = @options[:kenna_api_key]
         @kenna_connector_id = @options[:kenna_connector_id]
         @kenna_api_host = @options[:kenna_api_host]
-
-        @ratequeue = Limiter::RateQueue.new(480, interval: 3600, balanced: true)
         
+        @ratequeue = Limiter::RateQueue.new(680, interval: 3600, balanced: true)
+
         # Generate Temporary Lacework API Token
         print_good "Generating Temporary Lacework API Token"
         temp_api_token = generate_temporary_lacework_api_token(lacework_account, lacework_api_key, lacework_api_secret)

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -74,7 +74,8 @@ module Kenna
         @kenna_connector_id = @options[:kenna_connector_id]
         @kenna_api_host = @options[:kenna_api_host]
 
-        @ratequeue = Limiter::RateQueue.new(680, interval: 3600, balanced: true)
+        # per https://docs.lacework.com/api/v2/docs 480 requests allowed per hour (3600 sec)
+        @ratequeue = Limiter::RateQueue.new(480, interval: 3600, balanced: true)
 
         # Generate Temporary Lacework API Token
         print_good "Generating Temporary Lacework API Token"

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "lib/lacework_helper"
+require 'limiter'
 
 module Kenna
   module Toolkit
     class Lacework < Kenna::Toolkit::BaseTask
       include Kenna::Toolkit::LaceworkHelper
+
+      attr_reader :ratequeue
 
       def self.metadata
         {
@@ -71,6 +74,8 @@ module Kenna
         @kenna_connector_id = @options[:kenna_connector_id]
         @kenna_api_host = @options[:kenna_api_host]
 
+        @ratequeue = Limiter::RateQueue.new(480, interval: 3600, balanced: true)
+        
         # Generate Temporary Lacework API Token
         print_good "Generating Temporary Lacework API Token"
         temp_api_token = generate_temporary_lacework_api_token(lacework_account, lacework_api_key, lacework_api_secret)

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -64,7 +64,6 @@ module Kenna
       end
 
       def run(opts)
-        RestClient.log=STDOUT
         super
 
         lacework_account = @options[:lacework_account]
@@ -74,7 +73,7 @@ module Kenna
         @kenna_api_key = @options[:kenna_api_key]
         @kenna_connector_id = @options[:kenna_connector_id]
         @kenna_api_host = @options[:kenna_api_host]
-        
+
         @ratequeue = Limiter::RateQueue.new(680, interval: 3600, balanced: true)
 
         # Generate Temporary Lacework API Token

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -38,8 +38,8 @@ module Kenna
 
       def lacework_post(url:, body:, api_token:)
         ratequeue.shift
-        headers={'Authorization'=>"Bearer #{api_token}", 'Content-type'=>'application/json'}
-        response=http_post(url, headers, body, 3)
+        headers = { 'Authorization' => "Bearer #{api_token}", 'Content-type' => 'application/json' }
+        response = http_post(url, headers, body, 3)
 
         if response.code == 204
           print_error "Lacework API returned HTTP code 204: no results found"
@@ -71,8 +71,8 @@ module Kenna
 
       def lacework_get(url:, api_token:)
         ratequeue.shift
-        headers={'Authorization'=>"Bearer #{api_token}", 'Content-type'=>'application/json'}
-        response=http_get(url, headers, 3)
+        headers = { 'Authorization' => "Bearer #{api_token}", 'Content-type' => 'application/json' }
+        response = http_get(url, headers, 3)
 
         if response.code != "200"
           print_error "Lacework API returned HTTP code #{response.code}:"

--- a/tasks/connectors/lacework/lib/lacework_helper.rb
+++ b/tasks/connectors/lacework/lib/lacework_helper.rb
@@ -2,6 +2,7 @@
 
 require "net/http"
 require "uri"
+require "limiter"
 
 module Kenna
   module Toolkit
@@ -36,27 +37,16 @@ module Kenna
       end
 
       def lacework_post(url:, body:, api_token:)
-        uri = URI.parse(url)
+        ratequeue.shift
+        headers={'Authorization'=>"Bearer #{api_token}", 'Content-type'=>'application/json'}
+        response=http_post(url, headers, body, 3)
 
-        request = Net::HTTP::Post.new(uri)
-        request.content_type = "application/json"
-        request["Authorization"] = "Bearer #{api_token}"
-        request.body = body
-
-        req_options = {
-          use_ssl: uri.scheme == "https"
-        }
-
-        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-          http.request(request)
-        end
-
-        if response.code == "204"
+        if response.code == 204
           print_error "Lacework API returned HTTP code 204: no results found"
           return []
-        elsif response.code != "200"
+        elsif response.code != 200
           print_error "Lacework API returned HTTP code #{response.code}:"
-          print_error response.message
+          print_error response.net_http_res.message
           return []
         end
 
@@ -80,23 +70,13 @@ module Kenna
       end
 
       def lacework_get(url:, api_token:)
-        uri = URI.parse(url)
-
-        request = Net::HTTP::Get.new(uri)
-        request.content_type = "application/json"
-        request["Authorization"] = "Bearer #{api_token}"
-
-        req_options = {
-          use_ssl: uri.scheme == "https"
-        }
-
-        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-          http.request(request)
-        end
+        ratequeue.shift
+        headers={'Authorization'=>"Bearer #{api_token}", 'Content-type'=>'application/json'}
+        response=http_get(url, headers, 3)
 
         if response.code != "200"
           print_error "Lacework API returned HTTP code #{response.code}:"
-          print_error response.message
+          print_error response.net_http_res.message
           return nil
         end
 


### PR DESCRIPTION
# Problem
Lacework has API rate limiting at the rate of 480 requests per hour. Clients with enough data will hit this and currently the task doesn't have logic to work around this limitation, so the toolkit task will error out.

# Solution
Added the limiter gem to the toolkit and applied a rate of 480 per hour to get/post methods that retrieve data. Set to spread out requests.

Lacework makes use of a response header "".  This is a draft standard proposal from IETF, so I felt comfortable putting it's use in a shared http utility library of the toolkit provided it's not made required.

# Testing performed