### PR TITLE
Vm 2187 show api key

### DIFF
--- a/tasks/utilities/kenna_api_token_check/README.md
+++ b/tasks/utilities/kenna_api_token_check/README.md
@@ -1,0 +1,57 @@
+# Verifying Kenna API Key
+
+This task utility verifies the Kenna API key, also referred to as token, to a specific Kenna host.
+
+## Usage
+`task=kenna_api_key_check kenna_api_key=<API-Key> [api_host=<api_host] [show_api_key=<true|false>]
+
+api_host defaults to `api.kennasecurity.com`.
+show_api_key defaults to `false`.
+
+if <show_api_key> is `true`, then the full value of the Kenna API key is displayed.  This is considered unsecure.
+
+## Results
+
+As part of the toolkit, as secure version on the API key and the Kenna host. 
+After that the number of connectors, users, roles, asset groups (risk meters), and vulnerabilities are displayed.
+
+```
+> docker run -it kennasecurity/toolkit task=kenna_api_key_check kenna_api_key=$KENNA_API_KEY
+Running: Kenna::Toolkit::KennaApiTokenCheck
+[+] (20230227192955) Setting kenna_api_host to default value: api.kennasecurity.com
+[+] (20230227192955) Got option: task: kenna_api_key_check
+[+] (20230227192955) Got option: kenna_api_key: 1*******tXq
+[+] (20230227192955) Got option: kenna_api_host: api.kennasecurity.com
+[+] (20230227192955) 
+[+] (20230227192955) Launching the Kenna API Token Check task!
+[+] (20230227192956) 
+[+] (20230227192956) Connectors: 3
+[+] (20230227192957) Users: 224
+[+] (20230227192957) Roles: 21
+[+] (20230227193002) Asset Groups: 2
+[+] (20230227193002) Vulns: 143
+```
+
+If an HTTP `401 Unauthorized` status code is returned, then verifying the Kenna API key could prove useful.  To verify the Kenna API key, type in:
+
+```
+> docker run -it kennasecurity/toolkit task=kenna_api_key_check kenna_api_key=$KENNA_API_KEY show_api_key=yes
+[+] (20230306151130) Setting kenna_api_host to default value: api.kennasecurity.com
+[+] (20230306151130) Setting show_api_key to default value: no
+[+] (20230306151130) Got option: task: kenna_api_key_check
+[+] (20230306151130) Got option: kenna_api_key: 1*******tXq
+[+] (20230306151130) Got option: show_api_key: y*******yes
+[+] (20230306151130) Got option: kenna_api_host: api.kennasecurity.com
+[+] (20230306151130) 
+[+] (20230306151130) Launching the Kenna API Token Check task!
+[+] (20230306151131) 
+[ ] (20230306151131) Kenna API key: 2xTEfWtFB2yp4KYp2sWfLuRr13-9PqQu47jsAKQk5yDJMvXYjribhdY9t81EmtXq
+[+] (20230306151131) Connectors: 3
+[+] (20230306151132) Users: 226
+[+] (20230306151133) Roles: 21
+[+] (20230306151133) Asset Groups: 2
+[+] (20230306151133) Vulns: 143
+```
+
+To return the Kenna API key, the parameter `show_api_key` must be equal to `yes`.  
+

--- a/tasks/utilities/kenna_api_token_check/README.md
+++ b/tasks/utilities/kenna_api_token_check/README.md
@@ -3,10 +3,10 @@
 This task utility verifies the Kenna API key, also referred to as token, to a specific Kenna host.
 
 ## Usage
-`task=kenna_api_key_check kenna_api_key=<API-Key> [api_host=<api_host] [show_api_key=<ues|no>]
+`task=kenna_api_key_check kenna_api_key=<API-Key> [api_host=<api_host] [show_api_key=<yes|no>]
 
-api_host is optional and defaults to `api.kennasecurity.com`.
-show_api_key is optional and defaults to `no`.
+* api_host is optional and defaults to `api.kennasecurity.com`.
+* show_api_key is optional and defaults to `no`.
 
 if <show_api_key> is `yes`, then the full value of the Kenna API key is displayed.  This is considered unsecure.
 
@@ -52,4 +52,6 @@ If an HTTP `401 Unauthorized` status code is returned, then verifying the value 
 [+] (20230306151133) Asset Groups: 2
 [+] (20230306151133) Vulns: 143
 ```
+
+**Note:** Showing the value of the Kenna API key is considered **insecure**.
 

--- a/tasks/utilities/kenna_api_token_check/README.md
+++ b/tasks/utilities/kenna_api_token_check/README.md
@@ -3,12 +3,12 @@
 This task utility verifies the Kenna API key, also referred to as token, to a specific Kenna host.
 
 ## Usage
-`task=kenna_api_key_check kenna_api_key=<API-Key> [api_host=<api_host] [show_api_key=<true|false>]
+`task=kenna_api_key_check kenna_api_key=<API-Key> [api_host=<api_host] [show_api_key=<ues|no>]
 
-api_host defaults to `api.kennasecurity.com`.
-show_api_key defaults to `false`.
+api_host is optional and defaults to `api.kennasecurity.com`.
+show_api_key is optional and defaults to `no`.
 
-if <show_api_key> is `true`, then the full value of the Kenna API key is displayed.  This is considered unsecure.
+if <show_api_key> is `yes`, then the full value of the Kenna API key is displayed.  This is considered unsecure.
 
 ## Results
 
@@ -32,7 +32,7 @@ Running: Kenna::Toolkit::KennaApiTokenCheck
 [+] (20230227193002) Vulns: 143
 ```
 
-If an HTTP `401 Unauthorized` status code is returned, then verifying the Kenna API key could prove useful.  To verify the Kenna API key, type in:
+If an HTTP `401 Unauthorized` status code is returned, then verifying the value of the Kenna API key could prove useful.  To verify the value of the Kenna API key, type in:
 
 ```
 > docker run -it kennasecurity/toolkit task=kenna_api_key_check kenna_api_key=$KENNA_API_KEY show_api_key=yes
@@ -52,6 +52,4 @@ If an HTTP `401 Unauthorized` status code is returned, then verifying the Kenna 
 [+] (20230306151133) Asset Groups: 2
 [+] (20230306151133) Vulns: 143
 ```
-
-To return the Kenna API key, the parameter `show_api_key` must be equal to `yes`.  
 

--- a/tasks/utilities/kenna_api_token_check/kenna_api_token_check.rb
+++ b/tasks/utilities/kenna_api_token_check/kenna_api_token_check.rb
@@ -18,7 +18,12 @@ module Kenna
               type: "hostname",
               required: false,
               default: "api.kennasecurity.com",
-              description: "Kenna API Hostname" }
+              description: "Kenna API Hostname" },
+            { name: "show_api_key",
+              type: "flag",
+              required: false,
+              default: "no",
+              description: "Show API Key" }
           ]
         }
       end
@@ -28,6 +33,11 @@ module Kenna
 
         api_host = @options[:kenna_api_host]
         api_token = @options[:kenna_api_key]
+        show_api_key = @options[:show_api_key]
+
+        if show_api_key == :yes
+          print "\nKenna API key: #{api_token}\n"
+        end
 
         api_client = Kenna::Api::Client.new(api_token, api_host)
 

--- a/tasks/utilities/kenna_api_token_check/kenna_api_token_check.rb
+++ b/tasks/utilities/kenna_api_token_check/kenna_api_token_check.rb
@@ -35,8 +35,8 @@ module Kenna
         api_token = @options[:kenna_api_key]
         show_api_key = @options[:show_api_key]
 
-        if show_api_key == :yes
-          print "\nKenna API key: #{api_token}\n"
+        if show_api_key == "yes"
+          print "Kenna API key: #{api_token}"
         end
 
         api_client = Kenna::Api::Client.new(api_token, api_host)


### PR DESCRIPTION
## VM-2187

## Problem:
It is useful to display the value of the Kenna API key for debugging purposes.

## Solution
Have an optional parameter to display the value of the Kenna API key.