### PR TITLE
add omit_line_number option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,11 +64,11 @@ GEM
     minitest (5.18.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.14.0-aarch64-linux)
+    nokogiri (1.14.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-darwin)
+    nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-linux)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
@@ -197,4 +197,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.9
+   2.4.6

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -102,7 +102,7 @@ module Kenna
               ext_id = nil
               case finding["scan_type"]
               when "STATIC"
-                file = "#{finding['finding_details']['file_path']}"
+                file = finding['finding_details']['file_path'].to_s
                 file += ":#{finding['finding_details']['file_line_number']}" unless omit_line_number
                 ext_id = "[#{app_name}] - #{file}"
               when "DYNAMIC"

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -102,7 +102,8 @@ module Kenna
               ext_id = nil
               case finding["scan_type"]
               when "STATIC"
-                file = "#{finding['finding_details']['file_path']}:#{finding['finding_details']['file_line_number']}"
+                file = "#{finding['finding_details']['file_path']}"
+                file += ":#{finding['finding_details']['file_line_number']}" unless omit_line_number
                 ext_id = "[#{app_name}] - #{file}"
               when "DYNAMIC"
                 url = finding["finding_details"]["url"]

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -53,7 +53,7 @@ module Kenna
               type: "boolean",
               required: false,
               default: false,
-              description: "When set true, it will omit the line number at the end of file_locator."
+              description: "When set to true, it will omit the line number at the end of file_locator."
             }
           ]
         }

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -47,7 +47,13 @@ module Kenna
               type: "filename",
               required: false,
               default: "output/veracode",
-              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" }
+              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" },
+            {
+              name: "omit_line_number",
+              type: "boolean",
+              required: false,
+              default: false,
+              description: "When set true, it will omit the line number at the end of file_locator." }
 
           ]
         }

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -53,8 +53,8 @@ module Kenna
               type: "boolean",
               required: false,
               default: false,
-              description: "When set true, it will omit the line number at the end of file_locator." }
-
+              description: "When set true, it will omit the line number at the end of file_locator."
+            }
           ]
         }
       end


### PR DESCRIPTION
## Produce file locators without line numbers

### Problem

A client has reported that a number of their Kenna findings not closing after subsequent task runs after being resolved in Veracode. The reason seems to be that the findings are just dropping off of the api without ever showing a closed status in the data.  Since the file locators with line number are usually specific to their particular findings, this means we never see the asset again if the findings falls of the api. If we never see the asset again there's no chances for auto-close functionality to take effect.

### Solution

Provide an optional (to not break anyone's workflow) task option that when set causes us to omit the line number from file locator on non-SCA findings.