### PR TITLE
Veracode findings put omit lines in scope

### DIFF
--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -308,9 +308,9 @@ module Kenna
           end
         end
 
-        def issues(app_guid, app_name, tags, page_size)
+        def issues(app_guid, app_name, tags, page_size, omit_line_number)
           # Get Findings
-          get_findings(app_guid, app_name, tags, page_size)
+          get_findings(app_guid, app_name, tags, page_size, omit_line_number)
           # Get SCA Findings
           get_findings_sca(app_guid, app_name, tags, page_size)
 

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -75,7 +75,7 @@ module Kenna
           @category_recommendations = cat_rec_list
         end
 
-        def get_findings(app_guid, app_name, tags, page_size)
+        def get_findings(app_guid, app_name, tags, page_size, omit_line_number)
           print_debug "pulling issues for #{app_name}"
           puts "pulling issues for #{app_name}" # DBRO
           app_request = "#{FINDING_PATH}/#{app_guid}/findings?size=#{page_size}"

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -72,7 +72,6 @@ module Kenna
         @output_dir = "#{$basedir}/#{@options[:output_directory]}"
         @filename = ".json"
 
-
         client = Kenna::Toolkit::Veracode::FindingsClient.new(veracode_id, veracode_key, @output_dir, @filename, @kenna_api_host, @kenna_connector_id, @kenna_api_key)
 
         client.category_recommendations(page_size)

--- a/tasks/connectors/veracode_findings/veracode_findings.rb
+++ b/tasks/connectors/veracode_findings/veracode_findings.rb
@@ -65,11 +65,13 @@ module Kenna
         veracode_id = @options[:veracode_id]
         veracode_key = @options[:veracode_key]
         page_size = @options[:veracode_page_size]
+        omit_line_number = @options[:omit_line_number]
         @kenna_api_host = @options[:kenna_api_host]
         @kenna_api_key = @options[:kenna_api_key]
         @kenna_connector_id = @options[:kenna_connector_id]
         @output_dir = "#{$basedir}/#{@options[:output_directory]}"
         @filename = ".json"
+
 
         client = Kenna::Toolkit::Veracode::FindingsClient.new(veracode_id, veracode_key, @output_dir, @filename, @kenna_api_host, @kenna_connector_id, @kenna_api_key)
 
@@ -82,7 +84,7 @@ module Kenna
           guid = application.fetch("guid")
           appname = application.fetch("name").tr('"', "'")
           tags = application.fetch("tags")
-          client.issues(guid, appname, tags, page_size)
+          client.issues(guid, appname, tags, page_size, omit_line_number)
         end
 
         return unless @kenna_connector_id && @kenna_api_host && @kenna_api_key


### PR DESCRIPTION
## Problem
Recently implemented omit_line_number option is not in scope where used.

## Solution
At the beginning of the task run pull it out of the options hash and pass it as an argument into the method where it is used.