### PR TITLE
SUP-1171-lacework_map_vuln_description

### DIFF
--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -103,7 +103,8 @@ module Kenna
             "scanner_score": (vuln.dig("cveProps", "metadata", "NVD", "CVSSv3", "Score") || 0).to_i,
             "last_seen_at": vuln["props"]["last_updated_time"],
             "status": vuln["status"] == "Active" ? "open" : "closed",
-            "vuln_def_name": vuln["vulnId"]
+            "vuln_def_name": vuln["vulnId"],
+            "description": (vuln.dig("cveProps", "description") || '')
           }
 
           vulns_by_host[key].push(hsh)
@@ -136,7 +137,8 @@ module Kenna
             vuln_def_hash = {
               scanner_identifier: vuln[:scanner_identifier],
               scanner_type: vuln[:scanner_type],
-              name: vuln[:vuln_def_name]
+              name: vuln[:vuln_def_name],
+              description: vuln[:description]
             }
 
             create_kdi_asset_vuln(asset_hash.stringify_keys, vuln_hash.stringify_keys)

--- a/tasks/connectors/lacework/lacework.rb
+++ b/tasks/connectors/lacework/lacework.rb
@@ -138,6 +138,7 @@ module Kenna
               scanner_identifier: vuln[:scanner_identifier],
               scanner_type: vuln[:scanner_type],
               name: vuln[:vuln_def_name],
+              cve_identifiers: vuln[:vuln_def_name],
               description: vuln[:description]
             }
 


### PR DESCRIPTION
## Problem
With the set of fields the Lacework toolkit task brings in, vulns are scored, but technically informational, and don't have a visible description in the UI

## Solution
Map in 'description' vuln definition field. Map in 'cve_identifiers' vuln definition field.

![image](https://user-images.githubusercontent.com/51678532/234312913-a6292bc9-3456-4e72-8448-4b2599c0de98.png)

- cve description visible in Explore

![image](https://user-images.githubusercontent.com/51678532/234313130-65e37dd4-3881-429c-a200-6adc14b9b51a.png)

- vuln description visible on vuln detail page