### PR TITLE
Con 2926 veracode unique scanner ids

### DIFF
--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -8,6 +8,7 @@ require_relative "../lib/toolkit"
 
 require "timecop"
 require 'vcr'
+require 'webmock/rspec'
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"

--- a/spec/tasks/connectors/veracode_findings/fixtures/applications.json
+++ b/spec/tasks/connectors/veracode_findings/fixtures/applications.json
@@ -1,0 +1,16 @@
+{
+  "_embedded": {
+    "applications": [
+      {
+        "profile": {
+          "tags": "t1,t2",
+          "business_unit": {
+            "name": "BU"
+          },
+          "name": "app1"
+        },
+        "guid": "TESTGUID"
+      }
+    ]
+  }
+}

--- a/spec/tasks/connectors/veracode_findings/fixtures/findings.json
+++ b/spec/tasks/connectors/veracode_findings/fixtures/findings.json
@@ -1,0 +1,27 @@
+{
+  "_embedded": {
+    "findings": [
+      {
+        "scan_type": "STATIC",
+        "finding_details": {
+          "file_path": "a/b/c.sh",
+          "file_line_number": "1",
+          "severity": "low",
+          "cwe": {
+            "id": "TEST",
+            "name": "TEST NAME"
+          }
+        },
+        "issue_id": 123,
+        "finding_status": {
+          "status": "NOT CLOSED",
+          "new": true,
+          "first_found_date": "now",
+          "last_seen_date": "yesterday"
+        },
+        "description": "This is a bogus finding",
+        "violates_policy": false
+      }
+    ]
+  }
+}

--- a/spec/tasks/connectors/veracode_findings/fixtures/sca_findings.json
+++ b/spec/tasks/connectors/veracode_findings/fixtures/sca_findings.json
@@ -1,0 +1,5 @@
+{
+  "_embedded": {
+    "findings": []
+  }
+}

--- a/spec/tasks/connectors/veracode_findings/veracode_findings_stubs.rb
+++ b/spec/tasks/connectors/veracode_findings/veracode_findings_stubs.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+def read_fixture_file(filename)
+  File.read(File.join(%w[spec tasks connectors veracode_findings fixtures], filename))
+end
+
+def stub_findings_request
+  stub_request(:get, "https://api.veracode.com/appsec/v2/applications/TESTGUID/findings?size=100").to_return_json(body: read_fixture_file("findings.json"))
+end
+
+def stub_SCA_findings_request
+  stub_request(:get, "https://api.veracode.com/appsec/v2/applications/TESTGUID/findings?size=100").to_return_json(body: read_fixture_file("sca_findings.json"))
+end
+
+def stub_applications_request
+  stub_request(:get, Addressable::Template.new("https://api.veracode.com/appset/v1/applications?size=100"))
+    .to_return_json(body: read_fixture_file("applications.json"))
+end
+

--- a/spec/tasks/connectors/veracode_findings/veracode_findings_task_spec.rb
+++ b/spec/tasks/connectors/veracode_findings/veracode_findings_task_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rspec_helper"
+require_relative "veracode_findings_stubs"
+
+RSpec.describe Kenna::Toolkit::SnykV2Task do
+  subject(:task) { described_class.new }
+
+  describe "#run" do
+    let(:connector_run_success) { true }
+    let(:kenna_client) { instance_double(Kenna::Api::Client, upload_to_connector: { "data_file" => 12 }, run_files_on_connector: { "success" => connector_run_success }) }
+    let(:options) { { veracode_id: '', veracode_key: ''} }
+
+    before do
+      stub_findings_request
+      stub_SCA_findings_request
+      stub_applications_request
+      allow(Kenna::Api::Client).to receive(:new) { kenna_client }
+      spy_on_accumulators
+      task.run(options)
+    end
+
+    context "veracode findings" do
+
+      it "should map the scanner_identifier to include the application name and the issue id" do
+        expect(task.vuln_defs).to include(
+         an_object_having_attributes({
+            "scanner_identifier": "app1:123",
+          })
+        )
+        expect(task.assets.first.findings).to include(
+          an_object_having_attributes({
+            "scanner_identifier": "app1:123",
+            "cwe_identifiers": "CWE-TEST",
+          })
+        )
+      end
+
+    end
+  end
+
+  def spy_on_accumulators
+    subject.extend Kenna::Toolkit::KdiAccumulatorSpy
+  end
+end

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -109,7 +109,7 @@ module Kenna
                 url = finding["finding_details"]["url"]
                 ext_id = "[#{app_name}] - #{url}"
               end
-              finding_id = finding["issue_id"]
+              finding_id = "#{app_name}:#{finding["issue_id"]}"
               require 'pry'; binding.pry unless finding_id
 
               # Pull Status from finding["finding_status"]["status"]

--- a/tasks/connectors/veracode_findings/lib/veracode_client.rb
+++ b/tasks/connectors/veracode_findings/lib/veracode_client.rb
@@ -109,6 +109,8 @@ module Kenna
                 url = finding["finding_details"]["url"]
                 ext_id = "[#{app_name}] - #{url}"
               end
+              finding_id = finding["issue_id"]
+              require 'pry'; binding.pry unless finding_id
 
               # Pull Status from finding["finding_status"]["status"]
               # Per docs this shoule be "OPEN" or "CLOSED"
@@ -165,7 +167,7 @@ module Kenna
 
               # craft the vuln hash
               finding = {
-                "scanner_identifier" => cwe,
+                "scanner_identifier" => finding_id,
                 "scanner_type" => "veracode",
                 "severity" => scanner_score * 2,
                 "triage_state" => status,
@@ -177,7 +179,7 @@ module Kenna
               finding.compact!
 
               vuln_def = {
-                "scanner_identifier" => cwe,
+                "scanner_identifier" => finding_id,
                 "scanner_type" => "veracode",
                 "cwe_identifiers" => cwe,
                 "name" => cwe_name,
@@ -218,6 +220,8 @@ module Kenna
             findings.lazy.each do |finding|
               file = finding["finding_details"]["component_path"].first.fetch("path")
               ext_id = "[#{app_name}] - #{file}"
+              finding_id = finding["issue_id"]
+              require 'pry'; binding.pry unless finding_id
 
               # Pull Status from finding["finding_status"]["status"]
               # Per docs this shoule be "OPEN" or "CLOSED"
@@ -273,7 +277,7 @@ module Kenna
 
               # craft the vuln hash
               finding = {
-                "scanner_identifier" => cve,
+                "scanner_identifier" => finding_id,
                 "scanner_type" => "veracode",
                 "severity" => scanner_score * 2,
                 "triage_state" => status,
@@ -285,7 +289,7 @@ module Kenna
               finding.compact!
 
               vuln_def = {
-                "scanner_identifier" => cve,
+                "scanner_identifier" => finding_id,
                 "scanner_type" => "veracode",
                 "cwe_identifiers" => cwe,
                 "cve_identifiers" => cve,


### PR DESCRIPTION
CON-2926

update the scanner_id for fixes to use the app name and the unique issue ID. This does not unfortunately change SCA findings because those do not appear to have the required issue_id. However, those are not the findings causing our customer support ticket that leaded to this ticket. If we need to address that in the future we will do so in a new ticket.