### PR TITLE
Add ability to specify time as delta in seconds for Cylera

### DIFF
--- a/spec/tasks/connectors/cylera/cylera_task_spec.rb
+++ b/spec/tasks/connectors/cylera/cylera_task_spec.rb
@@ -50,5 +50,24 @@ RSpec.describe Kenna::Toolkit::CyleraTask do
         expect { task.run(options) }.to raise_error(SystemExit) { |e| expect(e.status).to_not be_zero }
       end
     end
+
+    context 'when time value is unexpected' do
+      let(:options) do
+        {
+          cylera_api_host: 'cylera.host',
+          cylera_api_user: 'api_user',
+          cylera_api_password: 'api_pass',
+          kenna_api_key: 'api_key',
+          kenna_api_host: 'kenna.example.com',
+          kenna_connector_id: '12',
+          cylera_last_seen_after: '60m'
+        }
+      end
+
+      it 'exits the script' do
+        expect { task.run(options) }.to raise_error(RuntimeError)
+      end
+    end
+
   end
 end

--- a/spec/tasks/connectors/cylera/cylera_task_spec.rb
+++ b/spec/tasks/connectors/cylera/cylera_task_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Kenna::Toolkit::CyleraTask do
       end
     end
 
-    context 'when time value is unexpected' do
+    context 'when time value is an unexpected format' do
       let(:options) do
         {
           cylera_api_host: 'cylera.host',

--- a/spec/tasks/connectors/cylera/cylera_task_spec.rb
+++ b/spec/tasks/connectors/cylera/cylera_task_spec.rb
@@ -68,6 +68,5 @@ RSpec.describe Kenna::Toolkit::CyleraTask do
         expect { task.run(options) }.to raise_error(RuntimeError)
       end
     end
-
   end
 end

--- a/tasks/connectors/cylera/cylera_task.rb
+++ b/tasks/connectors/cylera/cylera_task.rb
@@ -19,6 +19,7 @@ module Kenna
         'Resolved' => 'Closed',
         'Suppressed' => 'Closed'
       }.freeze
+      SECONDS = "s"
 
       def self.metadata
         {
@@ -63,28 +64,28 @@ module Kenna
             },
             {
               name: 'cylera_first_seen_before',
-              type: 'integer',
+              type: 'string',
               required: false,
               default: nil,
               description: 'Finds devices that were first seen before this epoch timestamp'
             },
             {
               name: 'cylera_first_seen_after',
-              type: 'integer',
+              type: 'string',
               required: false,
               default: nil,
               description: 'Finds devices that were first seen after this epoch timestamp'
             },
             {
               name: 'cylera_last_seen_before',
-              type: 'integer',
+              type: 'string',
               required: false,
               default: nil,
               description: 'Finds devices that were last seen before this epoch timestamp'
             },
             {
               name: 'cylera_last_seen_after',
-              type: 'integer',
+              type: 'string',
               required: false,
               default: nil,
               description: 'Finds devices that were last seen after this epoch timestamp'
@@ -263,10 +264,10 @@ module Kenna
         @inventory_devices_params = {
           ip_address: @options[:cylera_ip_address],
           mac_address: @options[:cylera_mac_address],
-          first_seen_before: @options[:cylera_first_seen_before],
-          first_seen_after: @options[:cylera_first_seen_after],
-          last_seen_before: @options[:cylera_last_seen_before],
-          last_seen_after: @options[:cylera_last_seen_after],
+          first_seen_before: handle_time_delta(@options[:cylera_first_seen_before]),
+          first_seen_after: handle_time_delta(@options[:cylera_first_seen_after]),
+          last_seen_before: handle_time_delta(@options[:cylera_last_seen_before]),
+          last_seen_after: handle_time_delta(@options[:cylera_last_seen_after]),
           vendor: @options[:cylera_vendor],
           type: @options[:cylera_type],
           model: @options[:cylera_model],
@@ -358,6 +359,19 @@ module Kenna
           result << mitigations['vendor_response']
         end
         result.join("\n") if result.present?
+      end
+
+      def handle_time_delta(time)
+        return case time
+               when nil
+                 time
+               when /^\d+#{SECONDS}$/i
+                 Time.now.to_i - time.to_i
+               when /^\d+$/
+                 time.to_i
+               else
+                 raise "Invalid time value: #{time}. Only epoch timestamp and delta in seconds are supported."
+               end
       end
     end
   end

--- a/tasks/connectors/cylera/cylera_task.rb
+++ b/tasks/connectors/cylera/cylera_task.rb
@@ -362,16 +362,16 @@ module Kenna
       end
 
       def handle_time_delta(time)
-        return case time
-               when nil
-                 time
-               when /^\d+#{SECONDS}$/i
-                 Time.now.to_i - time.to_i
-               when /^\d+$/
-                 time.to_i
-               else
-                 raise "Invalid time value: #{time}. Only epoch timestamp and delta in seconds are supported."
-               end
+        case time
+        when nil
+          time
+        when /^\d+#{SECONDS}$/i
+          Time.now.to_i - time.to_i
+        when /^\d+$/
+          time.to_i
+        else
+          raise "Invalid time value: #{time}. Only epoch timestamp and delta in seconds are supported."
+        end
       end
     end
   end

--- a/tasks/connectors/cylera/lib/client.rb
+++ b/tasks/connectors/cylera/lib/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'vcr'
+
 module Kenna
   module Toolkit
     module Cylera

--- a/tasks/connectors/cylera/lib/vcr.rb
+++ b/tasks/connectors/cylera/lib/vcr.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.allow_http_connections_when_no_cassette = true
+  config.hook_into :webmock
+  config.ignore_request do |request|
+    URI(request.uri).host != 'cylera.host'
+  end
+end
+
+def http_get(uri, headers)
+  use_cassette(URI(uri).query) do
+    super
+  end
+end
+
+def http_post(uri, headers, body)
+  use_cassette do
+    super
+  end
+end
+
+def use_cassette(query = '', &)
+  VCR.use_cassette('cylera', erb: { query: }, &)
+end

--- a/tasks/connectors/cylera/readme.md
+++ b/tasks/connectors/cylera/readme.md
@@ -46,10 +46,10 @@ For this task, you can leave off the Kenna API key and Kenna connector ID, so th
 | cylera_api_password | true | Cylera API user password | n/a |
 | cylera_ip_address | false | Partial or complete IP or subnet | n/a |
 | cylera_mac_address | false | Partial or complete MAC address | n/a |
-| cylera_first_seen_before | false | Finds devices that were first seen before this epoch timestamp | n/a |
-| cylera_first_seen_after | false | Finds devices that were first seen after this epoch timestamp | n/a |
-| cylera_last_seen_before | false | Finds devices that were last seen before this epoch timestamp | n/a |
-| cylera_last_seen_after | false | Finds devices that were last seen after this epoch timestamp | n/a |
+| cylera_first_seen_before | false | Finds devices that were first seen before this epoch timestamp or delta time in seconds | n/a |
+| cylera_first_seen_after | false | Finds devices that were first seen after this epoch timestamp or delta time in seconds | n/a |
+| cylera_last_seen_before | false | Finds devices that were last seen before this epoch timestamp or delta time in seconds | n/a |
+| cylera_last_seen_after | false | Finds devices that were last seen after this epoch timestamp or delta time in seconds | n/a |
 | cylera_vendor | false | Device vendor or manufacturer (e.g. Natus) | n/a |
 | cylera_type | false | Device type (e.g. EEG) | n/a |
 | cylera_model | false | Device model (e.g. NATUS NeuroWorks XLTECH EEG Unit) | n/a |


### PR DESCRIPTION
1. Added ability to specify relative time in seconds for time parameters, e.g. cylera_last_seen_after=60s
2. Reversed VCR back as tests are failing without it.
