### PR TITLE
Add ip_ignore_list to Cylera

### DIFF
--- a/spec/tasks/connectors/cylera/cylera_task_spec.rb
+++ b/spec/tasks/connectors/cylera/cylera_task_spec.rb
@@ -135,5 +135,47 @@ RSpec.describe Kenna::Toolkit::CyleraTask do
                          "ftp://ftp.software.ibm.com/ps/products/tcpip/fixes/v4.3os2/ic27721/README" })
       end
     end
+    context 'when ip_ignore_list is provided' do
+      before do
+        spy_on_accumulators
+        VCR.use_cassette('cylera') do
+          task.run(options.merge(ip_ignore_list: '0.0.0.0,192.168.1.0/24'))
+        end
+      end
+
+      it 'ignores matched ip address' do
+        expect(task.assets)
+          .to include({ "external_id" => "ae2e8de0-c764-11eb-8e8d-4627b9127261",
+                        "mac_address" => "00:15:bd:01:0f:10",
+                        "os" => "VxWorks",
+                        "hostname" => "dhcp-12-25-19-132",
+                        "priority" => 10,
+                        "tags" => ["Vendor:Group 4 Technology Ltd",
+                                   "Type:Network Access Control System",
+                                   "Model:Group 4 Tec Access Control / Security Management System",
+                                   "Class:Infrastructure",
+                                   "Location:Jersey City Medical Center, Jersey City, NJ",
+                                   "FDA Class:2",
+                                   "Serial Number:0000001",
+                                   "Version:4.0.1.0",
+                                   "VLAN:-1",
+                                   "AETitle:NBXXCU"],
+                        "vulns" => [{ "created_at" => "2022-09-10 02:48:11.000000000 +0000",
+                                      "last_seen_at" => "2022-09-10 02:48:11.000000000 +0000",
+                                      "scanner_identifier" => "CVE-2000-0761",
+                                      "scanner_score" => 6,
+                                      "scanner_type" => "Cylera",
+                                      "status" => "Open",
+                                      "vuln_def_name" => "CVE-2000-0761" }] })
+      end
+    end
+
+    context 'when ip_ignore_list contains unexpected values' do
+      it 'raises exception' do
+        VCR.use_cassette('cylera') do
+          expect { task.run(options.merge(ip_ignore_list: '0.0.0.0,192.168.1.0/43')) }.to raise_error(RuntimeError)
+        end
+      end
+    end
   end
 end

--- a/tasks/connectors/cylera/cylera_task.rb
+++ b/tasks/connectors/cylera/cylera_task.rb
@@ -322,7 +322,7 @@ module Kenna
         return nil if ip_ignore_list.nil? || ip_ignore_list.empty?
 
         begin
-          ip_ignore_list.split(",").map { |ip| IPAddr.new(ip) }
+          ip_ignore_list.split(",").map { |ip| IPAddr.new(ip.strip) }
         rescue StandardError => e
           raise "Exception raised during ip_ignore_list parameter parsing => #{e.message}"
         end

--- a/tasks/connectors/cylera/cylera_task.rb
+++ b/tasks/connectors/cylera/cylera_task.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'lib/client'
+require "ipaddr"
 
 module Kenna
   module Toolkit
@@ -201,6 +202,13 @@ module Kenna
               required: false,
               default: 'output/cylera',
               description: "If set, will write a file upon completion. Path is relative to #{$basedir}"
+            },
+            {
+              name: 'ip_ignore_list',
+              type: 'string',
+              required: false,
+              default: nil,
+              description: "The list of IP ranges that shouldn't be considered as locator"
             }
           ]
         }
@@ -275,6 +283,7 @@ module Kenna
         @api_host = @options[:cylera_api_host]
         @api_user = @options[:cylera_api_user]
         @api_password = @options[:cylera_api_password]
+        @ip_ignore_list = parse_ip_ignore_list(@options[:ip_ignore_list])
         @inventory_devices_params = {
           ip_address: @options[:cylera_ip_address],
           mac_address: @options[:cylera_mac_address],
@@ -309,15 +318,34 @@ module Kenna
         @kdi_version = 2
       end
 
+      def parse_ip_ignore_list(ip_ignore_list)
+        return nil if ip_ignore_list.nil? || ip_ignore_list.empty?
+
+        begin
+          ip_ignore_list.split(",").map { |ip| IPAddr.new(ip) }
+        rescue StandardError => e
+          raise "Exception raised during ip_ignore_list parameter parsing => #{e.message}"
+        end
+      end
+
       def extract_asset(device)
         {
-          'ip_address' => device['ip_address'],
+          'ip_address' => validate_ip(device['ip_address']),
           'mac_address' => device['mac_address'],
           'os' => device['os'],
           'hostname' => device['hostname'],
           'external_id' => device['id'],
           'tags' => tags(device)
         }.compact
+      end
+
+      def validate_ip(ip)
+        return ip if @ip_ignore_list.nil?
+
+        @ip_ignore_list.each do |ip_range|
+          return nil if ip_range.include? ip
+        end
+        ip
       end
 
       def extract_vuln(vulnerability)

--- a/tasks/connectors/cylera/readme.md
+++ b/tasks/connectors/cylera/readme.md
@@ -62,6 +62,7 @@ For this task, you can leave off the Kenna API key and Kenna connector ID, so th
 | cylera_page | false | Controls the page of results to return | 0 |
 | cylera_page_size | false | Controls the number of results in each response. Max 100. | 100 |
 | incremental | false | Pulls data from the last successful run | false |
+| ip_ignore_list | false | Comma separated list of IP addresses and ranges to ignore as locators, e.g. '0.0.0.0,127.0.0.0/24' | false |
 | kenna_api_key | false | Your API key | n/a |
 | kenna_api_host | false | API hostname -- Defaults to US API endpoint. | api.kennasecurity.com |
 | kenna_connector_id | false | If set, tries to upload to this connector | n/a |


### PR DESCRIPTION
During client testing it was discovered that a lot of IP addresses are difined incorrectly by Cylera (mostly 0.0.0.0 values).
So, this PR adds new parameter for Cylera task that allows to ignore IP addresses that are included in the provided IP ranges.