### PR TITLE
SUP 1320 - Remove display_all from sentinel asset query

### DIFF
--- a/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/lib/api_client.rb
@@ -40,8 +40,7 @@ module Kenna
 
         def assets(&)
           query = {
-            "display_asset" => 1,
-            "display_all" => 1
+            "display_asset" => 1
           }
 
           paginated("/asset", query, &)


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1320](https://kennasecurity.atlassian.net/browse/SUP-1320)

### Problem
There appears to be a performance a performance issue on the endpoint where we’re requesting data for Whitehat Sentinel pursuant to timeouts, page size changes do not appear to be resolving the issue.

### Solution
This has been confirmed to be siginficiantly alleviated by changing the parameters to show a more narrow scope of asset information on the /asset endpoint via removing the display_all parameter.

Tracing the code through the connector, and verifying the information we ingest- the information that is lost, is only pursuant to some tags, specifically from the asset hash response we get;
- tags
- asset_owner_name
- custom_asset_id


[SUP-1320]: https://kennasecurity.atlassian.net/browse/SUP-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ