### PR TITLE
Update ntt_sentinel_dynamic.rb to use stringified keys when calling create/find asset kdi helper

### DIFF
--- a/tasks/connectors/ntt_sentinel_dynamic/ntt_sentinel_dynamic.rb
+++ b/tasks/connectors/ntt_sentinel_dynamic/ntt_sentinel_dynamic.rb
@@ -107,7 +107,7 @@ module Kenna
                 finding = mapper.finding_hash(node)
                 vuln_def = mapper.vuln_def_hash(node)
 
-                create_kdi_asset_finding(asset, finding)
+                create_kdi_asset_finding(asset.stringify_keys, finding)
                 create_kdi_vuln_def(vuln_def.stringify_keys)
               end
             end


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1327](https://kennasecurity.atlassian.net/browse/SUP-1327)

### Problem
Toolkit sentinel task does not create all assets/applications that reported by sentinel using vuln endpoint
To find/create assets in kdi, we make use of "uniq" method which reads asset hash using string keys, while the asset hash that is provided by the sentinel task uses symbol keys - as a result, the comparison to find the asset is true for every asset but the first ({} == {}) regardless of if they were previously created or not 

### Solution
Stringify asset hash keys when using create_kdi_asset_finding method as used for vulns defs in create_kdi_vuln_def and similar to lacework connector:
https://github.com/KennaSecurity/toolkit/blob/67f737a103f58be5bee6cd1e13bc678a9888ab7e/tasks/connectors/lacework/lacework.rb#L125C39-L125C53

[SUP-1327]: https://kennasecurity.atlassian.net/browse/SUP-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ