### PR TITLE
SUP-1348 Get rid of infinite loop while going through paginated results for netsparker

### DIFF
--- a/tasks/connectors/netsparker/lib/netsparker_client.rb
+++ b/tasks/connectors/netsparker/lib/netsparker_client.rb
@@ -25,10 +25,10 @@ module Kenna
 
         def retrieve_all_scheduled_scans
           page = 1
-          scheduled_scan_result = scheduled_scan_result(page)
           schedule_scans = []
 
           loop do
+            scheduled_scan_result = scheduled_scan_result(page)
             schedule_scans.push(*scheduled_scan_result.fetch("List"))
             break if scheduled_scan_result["IsLastPage"]
 


### PR DESCRIPTION
## SUP-1348

# Problem
Netsparker toolkit task gets in an infinite loop when going through paginated results with more than one page, as the page number is increased but the results for new page is not retrieved within the loop, causing page 1 to be parsed indefinitely until the task OOM.

# Solution
Retrive the new page within the loop.
