### PR TITLE
SUP-1364 Wiz issues query clean up for bad request

### DIFF
--- a/tasks/connectors/wiz/lib/wiz_client.rb
+++ b/tasks/connectors/wiz/lib/wiz_client.rb
@@ -147,19 +147,10 @@ module Kenna
               subscriptionTags
             }
             note
-            serviceTicket {
-              externalId
-              name
-              url
-            }
             serviceTickets {
               externalId
               name
               url
-              action {
-                id
-                type
-              }
             }
           }"
         end


### PR DESCRIPTION
## SUP-1364

# Problem
Wiz is returning bad request when querying for issues in toolkit task

The bad request is caused by the action section in serviceTickets included in the issues_query, the use of "action" in serviceTickets is not found in wiz api docs

# Solution
Remove action section from the query - this is not in use in issues mapper therefore it has no impact

* As per wiz docs, serviceTicket is deprecated and returns null if used, therefore, I'm removing this section and leaving serviceTickets only as part of the clean up

February 2nd, 2023
9 months ago by Joe
Updated: Updated the [Get Issues](https://integrate.wiz.io/reference/issues-query) API query filter serviceTicket to serviceTickets. Using serviceTicket won't break your API, but will return null instead of a value.