### PR TITLE
update the task so that when there's no path, it input no path found …

### DIFF
--- a/tasks/connectors/github_secret_scanning/github_secret_scanning_task.rb
+++ b/tasks/connectors/github_secret_scanning/github_secret_scanning_task.rb
@@ -158,10 +158,13 @@ module Kenna
           org = matches[1]
           repo = matches[2]
           fail_task "Unable to extract repo info from #{url}." if org.blank? || repo.blank?
+          details = locations.first.fetch("details")
+          file_path = details.fetch("path","No Path Found")
 
           asset = {
             "url" => alert.fetch("html_url"),
-            "file" => locations.first.fetch("details").fetch("path"),
+            #"file" => locations.first.fetch("details").fetch("path"),
+            "file" => file_path,
             "application" => "#{org}/#{repo}"
           }
           asset.compact


### PR DESCRIPTION
Some of the data sent back from github secret scanning is missing the "path" information. Therefore, adding a clause that if there's no path, input default as "no path found"

