### PR TITLE
Truncate vuln_def_name to 246 chars

### DIFF
--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -246,6 +246,7 @@ module Kenna
         vuln_attributes["vuln_def_name"] = cvd["name"] if cvd["name"]
         vuln_attributes["scanner_score"] = cvd["scanner_score"] if cvd["scanner_score"]
         vuln_attributes["override_score"] = cvd["override_score"] if cvd["override_score"]
+        # vuln_def_name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
         vuln_attributes["vuln_def_name"] = vuln_attributes["vuln_def_name"].slice(0, MAX_VULN_DEF_NAME_LENGTH)
         vuln_attributes.compact!
         create_kdi_asset_vuln(asset_attributes, vuln_attributes)

--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -3,6 +3,8 @@
 module Kenna
   module Toolkit
     module BitsightHelpers
+      MAX_VULN_DEF_NAME_LENGTH = 246
+
       @headers = nil
       @bitsight_api_key = nil
       @company_guid = nil
@@ -244,6 +246,7 @@ module Kenna
         vuln_attributes["vuln_def_name"] = cvd["name"] if cvd["name"]
         vuln_attributes["scanner_score"] = cvd["scanner_score"] if cvd["scanner_score"]
         vuln_attributes["override_score"] = cvd["override_score"] if cvd["override_score"]
+        vuln_attributes["vuln_def_name"] = vuln_attributes["vuln_def_name"].slice(0, MAX_VULN_DEF_NAME_LENGTH)
         vuln_attributes.compact!
         create_kdi_asset_vuln(asset_attributes, vuln_attributes)
 


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1396](https://kennasecurity.atlassian.net/browse/SUP-1396)

### Problem:
When a SVD identifier over 255 characters is provided by a connector, Kenna truncates the identifier to 255 chars during creation, but fails to update existing SVDs as it attempts to find them based on the untruncated identifier

### Solution:
In toolkit Bitsight task: Truncate vuln_def_name to 246 chars to guarantee identifier in Kenna to be 255 chars max (identifier = scanner_type ("Bitsight " = 9 chars) + vuln_def_name (246 chars) = 255 chars)

[SUP-1396]: https://kennasecurity.atlassian.net/browse/SUP-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ