### PR TITLE
truncate cvd name to match vuln_def_name in vuln

### DIFF
--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -218,7 +218,8 @@ module Kenna
         end
 
         vuln_def_name = detected_service.nil? ? vuln_def_id : detected_service[0]
-        scanner_identifier = detected_service.nil? ? vuln_def_id : "#{detected_service[0].gsub(/^Allows insecure protocol: /im, '').gsub(/^Insecure signature algorithm: /im, '').to_s.tr(' ', '_').tr('-', '_').downcase.strip}_open_port"
+        # vuln_def_name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
+        scanner_identifier = detected_service.nil? ? vuln_def_id : "#{detected_service[0].gsub(/^Allows insecure protocol: /im, '').gsub(/^Insecure signature algorithm: /im, '').to_s.tr(' ', '_').tr('-', '_').downcase.strip}_open_port".slice(0, MAX_VULN_DEF_NAME_LENGTH)
         vd = {
           "scanner_identifier" => scanner_identifier
         }
@@ -246,8 +247,6 @@ module Kenna
         vuln_attributes["vuln_def_name"] = cvd["name"] if cvd["name"]
         vuln_attributes["scanner_score"] = cvd["scanner_score"] if cvd["scanner_score"]
         vuln_attributes["override_score"] = cvd["override_score"] if cvd["override_score"]
-        # vuln_def_name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
-        vuln_attributes["vuln_def_name"] = vuln_attributes["vuln_def_name"].slice(0, MAX_VULN_DEF_NAME_LENGTH)
         vuln_attributes.compact!
         create_kdi_asset_vuln(asset_attributes, vuln_attributes)
 

--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -255,6 +255,8 @@ module Kenna
         ### Put them through our mapper
         ###
         cvd.tap { |hs| hs.delete("scanner_identifier") }
+        # vuln_def name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
+        cvd["name"] = cvd["name"].slice(0, MAX_VULN_DEF_NAME_LENGTH)
         create_kdi_vuln_def(cvd)
       end
 

--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -218,8 +218,7 @@ module Kenna
         end
 
         vuln_def_name = detected_service.nil? ? vuln_def_id : detected_service[0]
-        # vuln_def_name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
-        scanner_identifier = detected_service.nil? ? vuln_def_id : "#{detected_service[0].gsub(/^Allows insecure protocol: /im, '').gsub(/^Insecure signature algorithm: /im, '').to_s.tr(' ', '_').tr('-', '_').downcase.strip}_open_port".slice(0, MAX_VULN_DEF_NAME_LENGTH)
+        scanner_identifier = detected_service.nil? ? vuln_def_id : "#{detected_service[0].gsub(/^Allows insecure protocol: /im, '').gsub(/^Insecure signature algorithm: /im, '').to_s.tr(' ', '_').tr('-', '_').downcase.strip}_open_port"
         vd = {
           "scanner_identifier" => scanner_identifier
         }
@@ -247,6 +246,8 @@ module Kenna
         vuln_attributes["vuln_def_name"] = cvd["name"] if cvd["name"]
         vuln_attributes["scanner_score"] = cvd["scanner_score"] if cvd["scanner_score"]
         vuln_attributes["override_score"] = cvd["override_score"] if cvd["override_score"]
+        # vuln_def_name needs to be max 246 to guarantee the identifier built in CVM ("Bitsight " + vuln_def_name) does not surpass 255 chars
+        vuln_attributes["vuln_def_name"] = vuln_attributes["vuln_def_name"].slice(0, MAX_VULN_DEF_NAME_LENGTH)
         vuln_attributes.compact!
         create_kdi_asset_vuln(asset_attributes, vuln_attributes)
 


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1396](https://kennasecurity.atlassian.net/browse/SUP-1396)

### Problem:
When a SVD identifier over 255 characters is provided by a connector, Kenna truncates the identifier to 255 chars during creation, but fails to update existing SVDs as it attempts to find them based on the untruncated identifier

### Solution:
In toolkit Bitsight task: Truncate cvd name to 246 chars to match vuln_def_name in vuln and to guarantee identifier in Kenna to be 255 chars max (identifier = scanner_type ("Bitsight " = 9 chars) + vuln_def_name (246 chars) = 255 chars)

[SUP-1396]: https://kennasecurity.atlassian.net/browse/SUP-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ