### PR TITLE
SUP-1426 Correct default page size for wiz issues

### DIFF
--- a/tasks/connectors/wiz/lib/wiz_client.rb
+++ b/tasks/connectors/wiz/lib/wiz_client.rb
@@ -6,9 +6,10 @@ module Kenna
       class Client
         class ApiError < StandardError; end
 
-        def initialize(client_id, client_secret, auth_endpoint, api_host, page_size, days_back, vuln_object_types, severity, issue_status)
+        def initialize(client_id, client_secret, auth_endpoint, api_host, page_size_vulns, page_size_issues, days_back, vuln_object_types, severity, issue_status)
           @api_host = api_host
-          @page_size = page_size
+          @page_size_vulns = page_size_vulns
+          @page_size_issues = page_size_issues
           @days_back = days_back
           @vuln_object_types = vuln_object_types
           @severity = severity
@@ -157,7 +158,7 @@ module Kenna
 
         def issues_params(after = nil)
           params = {
-            first: @page_size,
+            first: @page_size_issues,
             filterBy: {}
           }
           params[:after] = after if after
@@ -235,7 +236,7 @@ module Kenna
 
         def vulns_params(after = nil)
           params = {
-            first: @page_size,
+            first: @page_size_vulns,
             filterBy: {}
           }
           params[:after] = after if after

--- a/tasks/connectors/wiz/readme.md
+++ b/tasks/connectors/wiz/readme.md
@@ -29,7 +29,8 @@ Complete list of Options:
 | wiz_client_secret | true | WIZ client secret | n/a |
 | wiz_auth_endpoint | false | WIZ auth endpoint hostname used to get the authorization token. | auth.app.wiz.io |
 | wiz_api_host | true | WIZ API Endpoint URL. If schema is included, it should be between double quotes escaped. | n/a |
-| wiz_page_size | false | Maximum number of issues to retrieve in each page. | 5000 |
+| vuln_page_size | false | Maximum number of vulnerabilities to retrieve in each page. (1-5000) | 5000 |
+| issue_page_size | false | Maximum number of issues to retrieve in each page. (1-500) | 500 |
 | days_back | false | Integer days number to get the vulnerabilities/issues detected x days back TODAY. | n/a |
 | vuln_object_types | false | Array of object types for VULNS import. Allowed values: VIRTUAL_MACHINE,CONTAINER_IMAGE,SERVERLESS. Import all if not present. | n/a |
 | severity | false | Array of severity types for VULNS and ISSUES (ALL) import. Allowed values: CRITICAL,HIGH,MEDIUM,LOW,INFO. Import all if not present. | n/a |


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1426](https://kennasecurity.atlassian.net/browse/SUP-1426)

### Problem:
Running wiz task with import_type ALL or ISSUES with default wiz_page_size (5000) results in error "'first' must be less than or equal to 500" during issues import. As per wiz documentation, maximum "first" value for issues is 500 while for vulnerabilities it's 5000.

### Solution:
Implement separate parameters for issues page size and vulnerabilities page size.


[SUP-1426]: https://kennasecurity.atlassian.net/browse/SUP-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ