### PR TITLE
SUP-1405 Add region code for Insight Appsec API host

### DIFF
--- a/tasks/connectors/insight_appsec/insight_appsec_task.rb
+++ b/tasks/connectors/insight_appsec/insight_appsec_task.rb
@@ -28,6 +28,11 @@ module Kenna
               required: false,
               default: "INFORMATIONAL, LOW, MEDIUM, HIGH",
               description: "A list of [SAFE, INFORMATIONAL, LOW, MEDIUM, HIGH] (comma separated)" },
+            { name: "insight_appsec_region_code",
+              type: "string",
+              required: false,
+              default: "us",
+              description: "Region code to use for the Insight Appsec API host (us, us2, us3, eu, ca, au, ap)" },
             { name: "page_size",
               type: "integer",
               required: false,
@@ -102,12 +107,13 @@ module Kenna
       attr_reader :client
 
       def initialize_client
-        @client = Kenna::Toolkit::InsightAppSec::Client.new(@api_key, @app_name)
+        @client = Kenna::Toolkit::InsightAppSec::Client.new(@api_host, @api_key, @app_name)
       end
 
       def initialize_options
         @issue_severities = extract_list(:insight_appsec_issue_severity,
                                          %w[safe informational low medium high])
+        @api_host = "https://#{@options[:insight_appsec_region_code]}.api.insight.rapid7.com"
         @api_key = @options[:insight_appsec_api_key]
         @app_name = @options[:insight_appsec_app_name]
         @output_directory = @options[:output_directory]

--- a/tasks/connectors/insight_appsec/lib/insight_appsec_client.rb
+++ b/tasks/connectors/insight_appsec/lib/insight_appsec_client.rb
@@ -10,9 +10,9 @@ module Kenna
           "severity" => "vulnerability.severity",
           "status" => "vulnerability.status"
         }.freeze
-        HOST = "https://us.api.insight.rapid7.com"
 
-        def initialize(api_key, app_name)
+        def initialize(api_host, api_key, app_name)
+          @api_host = api_host
           @api_key  = api_key
           @app_name = app_name
           @headers  = { "Content-Type": "application/json", "X-Api-Key": api_key.to_s }
@@ -23,7 +23,7 @@ module Kenna
         end
 
         def receive_vulns(app_id, filters, page_number, page_size)
-          response = http_post("#{HOST}/ias/v1/search?size=#{page_size}&&index=#{page_number}", @headers, receive_query(app_id, filters))
+          response = http_post("#{@api_host}/ias/v1/search?size=#{page_size}&&index=#{page_number}", @headers, receive_query(app_id, filters))
 
           raise ApiError, "Unable to retrieve vulnerabilities, please check credentials." unless response
 
@@ -31,7 +31,7 @@ module Kenna
         end
 
         def receive_module(module_id)
-          response = http_get("#{HOST}/ias/v1/modules/#{module_id}", @headers)
+          response = http_get("#{@api_host}/ias/v1/modules/#{module_id}", @headers)
 
           raise ApiError, "Unable to retrieve modules, please check credentials." unless response
 
@@ -69,7 +69,7 @@ module Kenna
         end
 
         def receive_apps
-          response = http_get("#{HOST}/ias/v1/apps", @headers)
+          response = http_get("#{@api_host}/ias/v1/apps", @headers)
 
           raise ApiError, "Unable to retrieve applications, please check credentials." unless response
 

--- a/tasks/connectors/insight_appsec/readme.md
+++ b/tasks/connectors/insight_appsec/readme.md
@@ -26,6 +26,7 @@ Complete list of Options:
 | --- | --- | --- | --- |
 | insight_appsec_api_key | true | Insight AppSec User API key | n/a |
 | insight_appsec_app_name | true | Insight AppSec application name | n/a |
+| insight_appsec_region_code | false | Insight AppSec region code for API host (it should be one of: us, us2, us3, eu, ca, au, ap) | us |
 | insight_appsec_issue_severity | false | A list of [SAFE, INFORMATIONAL, LOW, MEDIUM, HIGH] (comma separated) | INFORMATIONAL, LOW, MEDIUM, HIGH |
 | page_size | false | The number of objects per page (currently limited from 1 to 100). | 500 |
 | batch_size | false | The maximum number of issues to submit to Kenna in each batch. | 100 |


### PR DESCRIPTION
## Summary

**Jira**: [SUP-1405](https://kennasecurity.atlassian.net/browse/SUP-1405)

### Problem:
Insight Appsec API host is hard coded for US region, while some customers need to make use of other regions

### Solution:
Add a region code parameter to build the API host

[SUP-1405]: https://kennasecurity.atlassian.net/browse/SUP-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ