### PR TITLE
adjust the code so that vuln_def name and the scanner_identifier are …

### DIFF
--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -159,7 +159,7 @@ module Kenna
 
                 # start finding section
                 finding_data = {
-                  "scanner_identifier" => "#{find_from['qid']} - #{find_from['id']}",
+                  "scanner_identifier" => name(find_from),
                   "scanner_type" => "QualysWas",
                   "severity" => find_from["severity"].to_i * 2,
                   "created_at" => find_from["firstDetectedDate"],
@@ -230,7 +230,7 @@ module Kenna
       end
 
       def name(find_from)
-        "#{find_from['qid']}-#{find_from['name']}"
+        "#{find_from['name']} - #{find_from['qid']} - #{find_from['id']}"
       end
 
       def status(find_from)

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -231,7 +231,7 @@ module Kenna
 
       def name(find_from)
         return if find_from.nil?
-        
+
         structured_name = [find_from['name'], find_from['qid'], find_from['id']].compact.join(' - ')
         structured_name unless structured_name.empty?
       end

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -230,7 +230,7 @@ module Kenna
       end
 
       def name(find_from)
-        return if find_from.nil? 
+        return if find_from.nil?
         
         structured_name = [find_from['name'], find_from['qid'], find_from['id']].compact.join(' - ')
         structured_name unless structured_name.empty?

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -230,7 +230,9 @@ module Kenna
       end
 
       def name(find_from)
-        "#{find_from['name']} - #{find_from['qid']} - #{find_from['id']}"
+        return if find_from.nil? 
+        structured_name = [find_from['name'], find_from['qid'], find_from['id']].compact.join(' - ')
+        structured_name unless structured_name.empty?
       end
 
       def status(find_from)

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -232,7 +232,7 @@ module Kenna
       def name(find_from)
         return if find_from.nil?
 
-        structured_name = [find_from['name'], find_from['qid'], find_from['id']].compact.join(' - ')
+        structured_name = [find_from['qid'], find_from['id'], find_from['name'],].compact.join(' - ')
         structured_name unless structured_name.empty?
       end
 

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -232,7 +232,7 @@ module Kenna
       def name(find_from)
         return if find_from.nil?
 
-        structured_name = [find_from['qid'], find_from['id'], find_from['name'],].compact.join(' - ')
+        structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join(' - ')
         structured_name unless structured_name.empty?
       end
 

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -231,6 +231,7 @@ module Kenna
 
       def name(find_from)
         return if find_from.nil? 
+        
         structured_name = [find_from['name'], find_from['qid'], find_from['id']].compact.join(' - ')
         structured_name unless structured_name.empty?
       end

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -232,7 +232,7 @@ module Kenna
       def name(find_from)
         return if find_from.nil?
 
-        structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join(' - ')
+        structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join('-')
         structured_name unless structured_name.empty?
       end
 


### PR DESCRIPTION
The order logic here indicate that we're selecting the svd based on the match between scanner identifier and external_unique_id. 

https://github.com/KennaSecurity/beehive/blob/master/lib/beehive/sharded/finding.rb#L85C25-L85C25

```
    @svd = q.where('scanner_vulnerability_definitions.created_at <= ?', created_at)
            .order([
                     'scanner_vulnerability_definitions.identifier = ? DESC',
                     [external_unique_id]
                   ])
            .first
```

Based on the original mapping in the toolkit, we're providing different vuln_def, vul_def_name then the scanner_identifier which are the 2 elements composing the svd identifier and external_unique_id. This sometimes cause the mismatch of the svd to findings. 

Proposing to make the vuln_def / vuln_def_name in the finding hash the same as the scanner_identifier to match the selection logic in our importer code. 
