### PR TITLE
refactor the code with adding options

### DIFF
--- a/tasks/connectors/qualys_was/README.md
+++ b/tasks/connectors/qualys_was/README.md
@@ -46,7 +46,7 @@ Run the QualysWas task following the guidelines on the main [toolkit help page](
 | kenna_api_host | hostname | false | Kenna API Hostname |
 | kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
 | output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
-| match_ScannerIdentifier_with_vuln_def_name | boolean | false | If true, the finding scanner_identifier and the vuln_def name will match the format 'QID - ID - Name'. If a connector first ran without this parameter and it is enabled in a later run, it will result in automatic resolution of the existing findings with the previous format ('QID - ID') and creation of new findings with the new format within CVM. |
+| match_finding_with_vuln_def | boolean | false | If true, the finding scanner_identifier and the vuln_def name will match the format 'QID - ID - Name'. If a connector first ran without this parameter and it is enabled in a later run, it will result in automatic resolution of the existing findings with the previous format ('QID - ID') and creation of new findings with the new format within CVM. |
 
 
 ## Example Command Line:

--- a/tasks/connectors/qualys_was/README.md
+++ b/tasks/connectors/qualys_was/README.md
@@ -46,7 +46,7 @@ Run the QualysWas task following the guidelines on the main [toolkit help page](
 | kenna_api_host | hostname | false | Kenna API Hostname |
 | kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
 | output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
-| match_ScannerIdentifier_with_vuln_def_name | boolean | false | If true, the Scanner Description in UI will be coming from the vuln_defs' name in original JSON file matched with scanner_identifier. Each imported finding unless it has the exact same qid, id, and name from source data, will be created as new one. |
+| match_ScannerIdentifier_with_vuln_def_name | boolean | false | If true, the finding scanner_identifier and the vuln_def name will match the format 'QID - ID - Name'. If a connector first ran without this parameter and it is enabled in a later run, it will result in automatic resolution of the existing findings with the previous format ('QID - ID') and creation of new findings with the new format within CVM. |
 
 
 ## Example Command Line:

--- a/tasks/connectors/qualys_was/README.md
+++ b/tasks/connectors/qualys_was/README.md
@@ -46,9 +46,10 @@ Run the QualysWas task following the guidelines on the main [toolkit help page](
 | kenna_api_host | hostname | false | Kenna API Hostname |
 | kenna_connector_id | integer | false | If set, we'll try to upload to this connector |
 | output_directory | filename | false | Will alter default filename for output. Path is relative to #{$basedir} |
+| match_ScannerIdentifier_with_vuln_def_name | boolean | false | If true, the Scanner Description in UI will be coming from the vuln_defs' name in original JSON file matched with scanner_identifier. Each imported finding unless it has the exact same qid, id, and name from source data, will be created as new one. |
 
 
 ## Example Command Line:
 
     toolkit:latest task=qualys_was qualys_was_domain=qualysapi.qg3.apps.qualys.com qualys_was_user=xxx qualys_was_password=xxx
-    qualys_was_api_version_url=/qps/rest/3.0/ qualys_was_score_filter=2 kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx
+    qualys_was_api_version_url=/qps/rest/3.0/ qualys_was_score_filter=2 kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx match_ScannerIdentifier_with_vuln_def_name=true

--- a/tasks/connectors/qualys_was/README.md
+++ b/tasks/connectors/qualys_was/README.md
@@ -52,4 +52,4 @@ Run the QualysWas task following the guidelines on the main [toolkit help page](
 ## Example Command Line:
 
     toolkit:latest task=qualys_was qualys_was_domain=qualysapi.qg3.apps.qualys.com qualys_was_user=xxx qualys_was_password=xxx
-    qualys_was_api_version_url=/qps/rest/3.0/ qualys_was_score_filter=2 kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx match_ScannerIdentifier_with_vuln_def_name=true
+    qualys_was_api_version_url=/qps/rest/3.0/ qualys_was_score_filter=2 kenna_connector_id=15xxxx kenna_api_host=api.kennasecurity.com kenna_api_key=xxx match_finding_with_vuln_def=true

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -172,7 +172,7 @@ module Kenna
                   "additional_fields" => details,
                   "vuln_def_name" => name(find_from)
                 }.tap do |f|
-                    f["triage_state"] = status(find_from) if find_from["status"].present?
+                  f["triage_state"] = status(find_from) if find_from["status"].present?
                 end
                 # in case any values are null, it's good to remove them
                 finding_data.compact!

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -128,6 +128,7 @@ module Kenna
                   max_records = 0
                 end
                 find_from = data["Finding"]
+                abort("Error: No finding data found. Exiting the process") if find_from.nil?
                 max_records += 1
                 total_count += 1
                 asset = {
@@ -235,6 +236,8 @@ module Kenna
       end
 
       def name(find_from)
+        substitute_nil_with_string_values(find_from, 'qid', 'id', 'name')
+
         if @options[:match_finding_with_vuln_def]
           structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join('-')
           structured_name unless structured_name.empty?
@@ -248,6 +251,16 @@ module Kenna
           IGNORE_STATUS[find_from["ignoredReason"].downcase]
         else
           STATUS[find_from["status"].downcase]
+        end
+      end
+      # set up function to check for nil value, if nil, we update the hash
+
+      def substitute_nil_with_string_values(hash, keys)
+        keys.each do |key|
+          if hash[key].nil?
+            puts "#{key} is nil, substituting with 'no #{key} found' "
+            hash[key] = "no #{key} found"
+          end
         end
       end
     end

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -173,7 +173,7 @@ module Kenna
                   "vuln_def_name" => name(find_from)
                 }.tap do |f|
                     f["triage_state"] = status(find_from) if find_from["status"].present?
-                  end
+                end
                 # in case any values are null, it's good to remove them
                 finding_data.compact!
 

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -108,8 +108,8 @@ module Kenna
 
         while more_records == true
           findings_response = qualys_was_get_webapp_findings(token, @options[:qualys_page_size].to_i, page)
-          more_records = findings_response["ServiceResponse"]["hasMoreRecords"] == "true"
           fail_task "there was a problem with the RESPONSE. Nil value provided" if findings_response.nil?
+          more_records = findings_response["ServiceResponse"]["hasMoreRecords"] == "true"
           findings << findings_response
           findings.each do |findg|
             findg.map do |_, finding|

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -236,7 +236,7 @@ module Kenna
       end
 
       def name(find_from)
-        substitute_nil_with_string_values(find_from, 'qid', 'id', 'name')
+        substitute_nil_with_string_values(find_from, ['qid', 'id', 'name'])
 
         if @options[:match_finding_with_vuln_def]
           structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join('-')

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -82,11 +82,11 @@ module Kenna
               required: false,
               default: "output/qualys_was",
               description: "If set, will write a file upon completion. Path is relative to #{$basedir}" },
-            { name: "match_ScannerIdentifier_with_vuln_def_name",
+            { name: "match_finding_with_vuln_def",
               type: "boolean",
               required: false,
               default: false,
-              description: "If true, the Scanner Description in UI will be coming from the vuln_defs' name in original JSON file matched with scanner_identifier. Each imported finding unless have the exact same qid, id, and name from source data, will be created as new one." }
+              description: "If true, the finding scanner_identifier and the vuln_def name will match the format 'QID - ID - Name'. If a connector first ran without this parameter and it is enabled in a later run, it will result in automatic resolution of the existing findings with the previous format ('QID - ID') and creation of new findings with the new format within CVM." }
           ]
         }
       end
@@ -164,7 +164,7 @@ module Kenna
 
                 # start finding section
                 finding_data = {
-                  "scanner_identifier" => @options[:match_ScannerIdentifier_with_vuln_def_name] ? name(find_from) : "#{find_from['qid']} - #{find_from['id']}",
+                  "scanner_identifier" => @options[:match_finding_with_vuln_def] ? name(find_from) : "#{find_from['qid']} - #{find_from['id']}",
                   "scanner_type" => "QualysWas",
                   "severity" => find_from["severity"].to_i * 2,
                   "created_at" => find_from["firstDetectedDate"],
@@ -235,7 +235,7 @@ module Kenna
       end
 
       def name(find_from)
-        if @options[:match_ScannerIdentifier_with_vuln_def_name]
+        if @options[:match_finding_with_vuln_def]
           return if find_from.nil?
 
           structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join('-')

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -253,7 +253,6 @@ module Kenna
           STATUS[find_from["status"].downcase]
         end
       end
-      # set up function to check for nil value, if nil, we update the hash
 
       def substitute_nil_with_string_values(hash, keys)
         keys.each do |key|

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -236,8 +236,6 @@ module Kenna
 
       def name(find_from)
         if @options[:match_finding_with_vuln_def]
-          return if find_from.nil?
-
           structured_name = [find_from['qid'], find_from['id'], find_from['name']].compact.join('-')
           structured_name unless structured_name.empty?
         else

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -109,7 +109,7 @@ module Kenna
         while more_records == true
           findings_response = qualys_was_get_webapp_findings(token, @options[:qualys_page_size].to_i, page)
           more_records = findings_response["ServiceResponse"]["hasMoreRecords"] == "true"
-          print_debug "there was a problem with the RESPONSE" if findings_response.nil?
+          fail_task "there was a problem with the RESPONSE. Nil value provided" if findings_response.nil?
           findings << findings_response
           findings.each do |findg|
             findg.map do |_, finding|
@@ -128,7 +128,10 @@ module Kenna
                   max_records = 0
                 end
                 find_from = data["Finding"]
-                abort("Error: No finding data found. Exiting the process") if find_from.nil?
+                if find_from.nil?
+                  print_error("Error: No Finding data found! Skipping this finding data!")
+                  next
+                end
                 max_records += 1
                 total_count += 1
                 asset = {


### PR DESCRIPTION
The order logic here indicate that we're selecting the svd based on the match between scanner identifier and external_unique_id.

https://github.com/KennaSecurity/beehive/blob/master/lib/beehive/sharded/finding.rb#L85C25-L85C25

    @svd = q.where('scanner_vulnerability_definitions.created_at <= ?', created_at)
            .order([
                     'scanner_vulnerability_definitions.identifier = ? DESC',
                     [external_unique_id]
                   ])
            .first
Based on the original mapping in the toolkit, we're providing different vuln_def, vul_def_name then the scanner_identifier which are the 2 elements composing the svd identifier and external_unique_id. This sometimes cause the mismatch of the svd to findings.

Proposing to provide an options in the toolkit to  make the vuln_def / vuln_def_name in the finding hash the same as the scanner_identifier to match the selection logic in our importer code.