### PR TITLE
Upgrade nokogiri to 1.16.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,11 +64,13 @@ GEM
     minitest (5.20.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.15.3-aarch64-linux)
+    nokogiri (1.16.2-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-linux)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
@@ -80,7 +82,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
     regexp_parser (2.6.1)
     rest-client (2.1.0)
@@ -169,6 +171,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,4 +204,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.6
+   2.5.6


### PR DESCRIPTION
Nokogiri v1.16.2 upgrades the version of its dependency libxml2 to [v2.12.5](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.5).

libxml2 v2.12.5 addresses the following vulnerability:

https://github.com/advisories/GHSA-x77r-6xxm-wjmx / https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25062
described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/604
patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/92721970
Please note that this advisory only applies to the CRuby implementation of Nokogiri < 1.16.2, and only if the packaged libraries are being used. If you've overridden defaults at installation time to use system libraries instead of packaged libraries, you should instead pay attention to your distro's libxml2 release announcements.