### PR TITLE
SUP-1524 Whitesource task API change from v1.3 to v1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem "rspec"
   gem "rubocop", require: false
   gem "solargraph", require: false
+  gem 'yard', '>= 0.9.36'
   gem "timecop"
   gem "vcr", "~> 6.1"
   gem "webmock", "~> 3.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
     netrc (0.11.0)
     nokogiri (1.16.2-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
@@ -163,12 +165,11 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
+    yard (0.9.36)
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux
@@ -196,9 +197,10 @@ DEPENDENCIES
   tty-pager
   vcr (~> 6.1)
   webmock (~> 3.18)
+  yard (>= 0.9.36)
 
 RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.6
+   2.4.10

--- a/tasks/connectors/whitesource/lib/whitesource_client.rb
+++ b/tasks/connectors/whitesource/lib/whitesource_client.rb
@@ -5,10 +5,9 @@ module Kenna
     module Whitesource
       class Client
         class ApiError < StandardError; end
-        API_BASE_URL = "https://saas.whitesourcesoftware.com/api/v1.3"
 
-        def initialize(user_key, request_type, request_token, alert_type, days_back)
-          @endpoint = API_BASE_URL
+        def initialize(api_base_url, user_key, request_type, request_token, alert_type, days_back)
+          @endpoint = api_base_url
           @headers = { "accept": "application/json", "content-type": "application/json" }
           @user_key = user_key
           @request_type = request_type

--- a/tasks/connectors/whitesource/lib/whitesource_client.rb
+++ b/tasks/connectors/whitesource/lib/whitesource_client.rb
@@ -6,7 +6,7 @@ module Kenna
       class Client
         class ApiError < StandardError; end
 
-        def initialize(api_base_url, user_key, request_type, request_token, alert_type, days_back)
+        def initialize(user_key, request_type, request_token, alert_type, days_back, api_base_url)
           @endpoint = api_base_url
           @headers = { "accept": "application/json", "content-type": "application/json" }
           @user_key = user_key

--- a/tasks/connectors/whitesource/lib/whitesource_client.rb
+++ b/tasks/connectors/whitesource/lib/whitesource_client.rb
@@ -7,7 +7,7 @@ module Kenna
         class ApiError < StandardError; end
 
         def initialize(user_key, request_type, request_token, alert_type, days_back, api_base_url)
-          @endpoint = api_base_url
+          @endpoint = "https://#{api_base_url}/api/v1.4"
           @headers = { "accept": "application/json", "content-type": "application/json" }
           @user_key = user_key
           @request_type = request_type

--- a/tasks/connectors/whitesource/readme.md
+++ b/tasks/connectors/whitesource/readme.md
@@ -6,7 +6,7 @@ To run this task, you need the following information from Whitesource:
 
 1. Whitesource user key
 2. Whitesource token for organization, product, or project
-3. Whitesource API base URL
+3. Whitesource environment API v4 base URL without prefix e.g. saas.mend.io
 
 ## Command Line
 
@@ -21,16 +21,6 @@ Recommended Steps:
 5. Click on the name of the connector to get the connector ID
 6. Run the task with Whitesource Keys and Kenna Key/connector ID
 
-**Example Command:**
-
-```shell
-docker run -it --rm \
--v ~/Desktop/toolkit_input:/opt/app/toolkit/input \
--v ~/Desktop/toolkit_output:/opt/app/toolkit/output \
--t toolkit:latest task=whitesource:whitesource_user_key=<your_whitesource_user_key>:whitesource_request_token=<your_whitesource_request_token>:whitesource_api_base='"<your_whitesource_api_base_url>"'
-```
-
-**Note:** When specifying the `whitesource_api_base` URL, ensure to enclose the URL in single quotes `' '` if it's already surrounded by double quotes `" "`. This is necessary to correctly pass the URL as a parameter.
 
 Complete list of Options:
 
@@ -46,4 +36,4 @@ Complete list of Options:
 | kenna_api_host            | false    | Kenna API Hostname if not the US shared.                                                                                                                                                                             | api.kennasecurity.com  |
 | kenna_connector_id        | false    | If set, we'll try to upload to this connector.                                                                                                                                                                       | n/a                    |
 | output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}.                                                                                                                                          | output/whitesource     |
-| whitesource_api_base      | true    | Whitesource API base URL.                                                                                                                                           | n/a                    |
+| whitesource_api_base      | true    | Whitesource environment API v4 base URL without prefix e.g. saas.mend.io URL.                                                                                                                                           | n/a                    |

--- a/tasks/connectors/whitesource/readme.md
+++ b/tasks/connectors/whitesource/readme.md
@@ -4,9 +4,9 @@ This toolkit brings in data from Whitesource.
 
 To run this task, you need the following information from Whitesource:
 
-1. Whitesource user key.
-2. Whitesource token for organization, product, or project.
-3. Whitesource API base URL.
+1. Whitesource user key
+2. Whitesource token for organization, product, or project
+3. Whitesource API base URL
 
 ## Command Line
 
@@ -14,12 +14,12 @@ See the main Toolkit for instructions on running tasks. For this task, if you le
 
 Recommended Steps:
 
-1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner.
-2. Review output for expected data.
-3. Create a Kenna Data Importer connector in Kenna (example name: Whitesource KDI).
-4. Manually run the connector with the JSON from step 1.
-5. Click on the name of the connector to get the connector ID.
-6. Run the task with Whitesource Keys and Kenna Key/connector ID.
+1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner
+2. Review output for expected data
+3. Create a Kenna Data Importer connector in Kenna (example name: Whitesource KDI)
+4. Manually run the connector with the JSON from step 1
+5. Click on the name of the connector to get the connector ID
+6. Run the task with Whitesource Keys and Kenna Key/connector ID
 
 **Example Command:**
 

--- a/tasks/connectors/whitesource/readme.md
+++ b/tasks/connectors/whitesource/readme.md
@@ -1,38 +1,49 @@
-## Running the Whitesource task 
+## Running the Whitesource task
 
-This toolkit brings in data from Whitesource
+This toolkit brings in data from Whitesource.
 
-To run this task you need the following information from Whitesource: 
+To run this task, you need the following information from Whitesource:
 
 1. Whitesource user key.
-2. Whitesource token for organization, product or project.
+2. Whitesource token for organization, product, or project.
+3. Whitesource API base URL.
 
 ## Command Line
 
-See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a json file in the default or specified output directory. You can review the file before attempting to upload to the Kenna directly.
+See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a JSON file in the default or specified output directory. You can review the file before attempting to upload it to Kenna directly.
 
-Recommended Steps: 
+Recommended Steps:
 
-1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner
-1. Review output for expected data
-1. Create Kenna Data Importer connector in Kenna (example name: Whitesource KDI) 
-1, Manually run the connector with the json from step 1 
-1. Click on the name of the connector to get the connector id
-1. Run the task with Whitesource Keys and Kenna Key/connector id
+1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner.
+2. Review output for expected data.
+3. Create a Kenna Data Importer connector in Kenna (example name: Whitesource KDI).
+4. Manually run the connector with the JSON from step 1.
+5. Click on the name of the connector to get the connector ID.
+6. Run the task with Whitesource Keys and Kenna Key/connector ID.
 
+**Example Command:**
 
+```shell
+docker run -it --rm \
+-v ~/Desktop/toolkit_input:/opt/app/toolkit/input \
+-v ~/Desktop/toolkit_output:/opt/app/toolkit/output \
+-t toolkit:latest task=whitesource:whitesource_user_key=<your_whitesource_user_key>:whitesource_request_token=<your_whitesource_request_token>:whitesource_api_base='"<your_whitesource_api_base_url>"'
+```
+
+**Note:** When specifying the `whitesource_api_base` URL, ensure to enclose the URL in single quotes `' '` if it's already surrounded by double quotes `" "`. This is necessary to correctly pass the URL as a parameter.
 
 Complete list of Options:
 
-| Option                    | Required | Description                                                                                                                                                                                                          | default                |
+| Option                    | Required | Description                                                                                                                                                                                                          | Default                |
 |---------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| whitesource_user_key      | true     | Whitesource user key                                                                                                                                                                                                 | n/a                    |
-| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided                                                                                                                                    | organization           |
-| whitesource_request_token | true     | The token required for the request type e.g. Org token, Product token, Project token. The token for organization is also know as API Key.                                                                            | n/a                    |
-| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION NEW_MINOR_VERSION SECURITY_VULNERABILITY REJECTED_BY_POLICY_RESOURCE MULTIPLE_LIBRARY_VERSIONS HIGH_SEVERITY_BUG MULTIPLE_LICENSES REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
+| whitesource_user_key      | true     | Whitesource user key.                                                                                                                                                                                                | n/a                    |
+| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided.                                                                                                                                   | organization           |
+| whitesource_request_token | true     | The token required for the request type e.g., Org token, Product token, Project token. The token for an organization is also known as the API Key.                                                                   | n/a                    |
+| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION, NEW_MINOR_VERSION, SECURITY_VULNERABILITY, REJECTED_BY_POLICY_RESOURCE, MULTIPLE_LIBRARY_VERSIONS, HIGH_SEVERITY_BUG, MULTIPLE_LICENSES, REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
 | whitesource_days_back     | false    | Get results n days back up to today. Default gets all history.                                                                                                                                                       | n/a                    |
-| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches                                                                                                                                                                      | 100                    |
-| kenna_api_key             | false    | Kenna API Key for use with connector option                                                                                                                                                                          | n/a                    |
-| kenna_api_host            | false    | Kenna API Hostname if not US shared                                                                                                                                                                                  | api.kennasecurity.com  |
-| kenna_connector_id        | false    | If set, we'll try to upload to this connector                                                                                                                                                                        | n/a                    |
-| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}                                                                                                                                           | output/whitesource     |
+| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches.                                                                                                                                                                     | 100                    |
+| kenna_api_key             | false    | Kenna API Key for use with the connector option.                                                                                                                                                                     | n/a                    |
+| kenna_api_host            | false    | Kenna API Hostname if not the US shared.                                                                                                                                                                             | api.kennasecurity.com  |
+| kenna_connector_id        | false    | If set, we'll try to upload to this connector.                                                                                                                                                                       | n/a                    |
+| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}.                                                                                                                                          | output/whitesource     |
+| whitesource_api_base      | true    | Whitesource API base URL.                                                                                                                                           | n/a                    |

--- a/tasks/connectors/whitesource/readme.md
+++ b/tasks/connectors/whitesource/readme.md
@@ -1,49 +1,38 @@
 ## Running the Whitesource task
 
-This toolkit brings in data from Whitesource.
+This toolkit brings in data from Whitesource
 
-To run this task, you need the following information from Whitesource:
+To run this task you need the following information from Whitesource:
 
-1. Whitesource user key
-2. Whitesource token for organization, product, or project
-3. Whitesource API base URL
+1. Whitesource user key.
+2. Whitesource token for organization, product or project.
 
 ## Command Line
 
-See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a JSON file in the default or specified output directory. You can review the file before attempting to upload it to Kenna directly.
+See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a json file in the default or specified output directory. You can review the file before attempting to upload to the Kenna directly.
 
 Recommended Steps:
 
 1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner
-2. Review output for expected data
-3. Create a Kenna Data Importer connector in Kenna (example name: Whitesource KDI)
-4. Manually run the connector with the JSON from step 1
-5. Click on the name of the connector to get the connector ID
-6. Run the task with Whitesource Keys and Kenna Key/connector ID
+1. Review output for expected data
+1. Create Kenna Data Importer connector in Kenna (example name: Whitesource KDI)
+1, Manually run the connector with the json from step 1
+1. Click on the name of the connector to get the connector id
+1. Run the task with Whitesource Keys and Kenna Key/connector id
 
-**Example Command:**
 
-```shell
-docker run -it --rm \
--v ~/Desktop/toolkit_input:/opt/app/toolkit/input \
--v ~/Desktop/toolkit_output:/opt/app/toolkit/output \
--t toolkit:latest task=whitesource:whitesource_user_key=<your_whitesource_user_key>:whitesource_request_token=<your_whitesource_request_token>:whitesource_api_base='"<your_whitesource_api_base_url>"'
-```
-
-**Note:** When specifying the `whitesource_api_base` URL, ensure to enclose the URL in single quotes `' '` if it's already surrounded by double quotes `" "`. This is necessary to correctly pass the URL as a parameter.
 
 Complete list of Options:
 
-| Option                    | Required | Description                                                                                                                                                                                                          | Default                |
+| Option                    | Required | Description                                                                                                                                                                                                          | default                |
 |---------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| whitesource_user_key      | true     | Whitesource user key.                                                                                                                                                                                                | n/a                    |
-| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided.                                                                                                                                   | organization           |
-| whitesource_request_token | true     | The token required for the request type e.g., Org token, Product token, Project token. The token for an organization is also known as the API Key.                                                                   | n/a                    |
-| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION, NEW_MINOR_VERSION, SECURITY_VULNERABILITY, REJECTED_BY_POLICY_RESOURCE, MULTIPLE_LIBRARY_VERSIONS, HIGH_SEVERITY_BUG, MULTIPLE_LICENSES, REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
+| whitesource_user_key      | true     | Whitesource user key                                                                                                                                                                                                 | n/a                    |
+| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided                                                                                                                                    | organization           |
+| whitesource_request_token | true     | The token required for the request type e.g. Org token, Product token, Project token. The token for organization is also know as API Key.                                                                            | n/a                    |
+| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION NEW_MINOR_VERSION SECURITY_VULNERABILITY REJECTED_BY_POLICY_RESOURCE MULTIPLE_LIBRARY_VERSIONS HIGH_SEVERITY_BUG MULTIPLE_LICENSES REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
 | whitesource_days_back     | false    | Get results n days back up to today. Default gets all history.                                                                                                                                                       | n/a                    |
-| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches.                                                                                                                                                                     | 100                    |
-| kenna_api_key             | false    | Kenna API Key for use with the connector option.                                                                                                                                                                     | n/a                    |
-| kenna_api_host            | false    | Kenna API Hostname if not the US shared.                                                                                                                                                                             | api.kennasecurity.com  |
-| kenna_connector_id        | false    | If set, we'll try to upload to this connector.                                                                                                                                                                       | n/a                    |
-| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}.                                                                                                                                          | output/whitesource     |
-| whitesource_api_base      | true    | Whitesource API base URL.                                                                                                                                           | n/a                    |
+| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches                                                                                                                                                                      | 100                    |
+| kenna_api_key             | false    | Kenna API Key for use with connector option                                                                                                                                                                          | n/a                    |
+| kenna_api_host            | false    | Kenna API Hostname if not US shared                                                                                                                                                                                  | api.kennasecurity.com  |
+| kenna_connector_id        | false    | If set, we'll try to upload to this connector                                                                                                                                                                        | n/a                    |
+| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}                                                                                                                                           | output/whitesource     |

--- a/tasks/connectors/whitesource/readme.md
+++ b/tasks/connectors/whitesource/readme.md
@@ -1,38 +1,49 @@
 ## Running the Whitesource task
 
-This toolkit brings in data from Whitesource
+This toolkit brings in data from Whitesource.
 
-To run this task you need the following information from Whitesource:
+To run this task, you need the following information from Whitesource:
 
-1. Whitesource user key.
-2. Whitesource token for organization, product or project.
+1. Whitesource user key
+2. Whitesource token for organization, product, or project
+3. Whitesource API base URL
 
 ## Command Line
 
-See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a json file in the default or specified output directory. You can review the file before attempting to upload to the Kenna directly.
+See the main Toolkit for instructions on running tasks. For this task, if you leave off the Kenna API Key and Kenna Connector ID, the task will create a JSON file in the default or specified output directory. You can review the file before attempting to upload it to Kenna directly.
 
 Recommended Steps:
 
 1. Run with Whitesource Keys only to ensure you are able to get data properly from the scanner
-1. Review output for expected data
-1. Create Kenna Data Importer connector in Kenna (example name: Whitesource KDI)
-1, Manually run the connector with the json from step 1
-1. Click on the name of the connector to get the connector id
-1. Run the task with Whitesource Keys and Kenna Key/connector id
+2. Review output for expected data
+3. Create a Kenna Data Importer connector in Kenna (example name: Whitesource KDI)
+4. Manually run the connector with the JSON from step 1
+5. Click on the name of the connector to get the connector ID
+6. Run the task with Whitesource Keys and Kenna Key/connector ID
 
+**Example Command:**
 
+```shell
+docker run -it --rm \
+-v ~/Desktop/toolkit_input:/opt/app/toolkit/input \
+-v ~/Desktop/toolkit_output:/opt/app/toolkit/output \
+-t toolkit:latest task=whitesource:whitesource_user_key=<your_whitesource_user_key>:whitesource_request_token=<your_whitesource_request_token>:whitesource_api_base='"<your_whitesource_api_base_url>"'
+```
+
+**Note:** When specifying the `whitesource_api_base` URL, ensure to enclose the URL in single quotes `' '` if it's already surrounded by double quotes `" "`. This is necessary to correctly pass the URL as a parameter.
 
 Complete list of Options:
 
-| Option                    | Required | Description                                                                                                                                                                                                          | default                |
+| Option                    | Required | Description                                                                                                                                                                                                          | Default                |
 |---------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| whitesource_user_key      | true     | Whitesource user key                                                                                                                                                                                                 | n/a                    |
-| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided                                                                                                                                    | organization           |
-| whitesource_request_token | true     | The token required for the request type e.g. Org token, Product token, Project token. The token for organization is also know as API Key.                                                                            | n/a                    |
-| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION NEW_MINOR_VERSION SECURITY_VULNERABILITY REJECTED_BY_POLICY_RESOURCE MULTIPLE_LIBRARY_VERSIONS HIGH_SEVERITY_BUG MULTIPLE_LICENSES REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
+| whitesource_user_key      | true     | Whitesource user key.                                                                                                                                                                                                | n/a                    |
+| whitesource_request_type  | false    | One of [organization, product, project]. The corresponding token must be provided.                                                                                                                                   | organization           |
+| whitesource_request_token | true     | The token required for the request type e.g., Org token, Product token, Project token. The token for an organization is also known as the API Key.                                                                   | n/a                    |
+| whitesource_alert_type    | false    | The type of alert to import. Allowed: NEW_MAJOR_VERSION, NEW_MINOR_VERSION, SECURITY_VULNERABILITY, REJECTED_BY_POLICY_RESOURCE, MULTIPLE_LIBRARY_VERSIONS, HIGH_SEVERITY_BUG, MULTIPLE_LICENSES, REJECTED_DEFACTO_RESOURCE | SECURITY_VULNERABILITY |
 | whitesource_days_back     | false    | Get results n days back up to today. Default gets all history.                                                                                                                                                       | n/a                    |
-| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches                                                                                                                                                                      | 100                    |
-| kenna_api_key             | false    | Kenna API Key for use with connector option                                                                                                                                                                          | n/a                    |
-| kenna_api_host            | false    | Kenna API Hostname if not US shared                                                                                                                                                                                  | api.kennasecurity.com  |
-| kenna_connector_id        | false    | If set, we'll try to upload to this connector                                                                                                                                                                        | n/a                    |
-| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}                                                                                                                                           | output/whitesource     |
+| kenna_batch_size          | false    | Maximum number of issues to retrieve in batches.                                                                                                                                                                     | 100                    |
+| kenna_api_key             | false    | Kenna API Key for use with the connector option.                                                                                                                                                                     | n/a                    |
+| kenna_api_host            | false    | Kenna API Hostname if not the US shared.                                                                                                                                                                             | api.kennasecurity.com  |
+| kenna_connector_id        | false    | If set, we'll try to upload to this connector.                                                                                                                                                                       | n/a                    |
+| output_directory          | false    | If set, will write a file upon completion. Path is relative to #{$basedir}.                                                                                                                                          | output/whitesource     |
+| whitesource_api_base      | true    | Whitesource API base URL.                                                                                                                                           | n/a                    |

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -71,7 +71,7 @@ module Kenna
 
         initialize_options
 
-        puts "Introduce the API Base URL (v1.4) of your Mend Organization:"
+        puts "Please enter the Base URL for your Mend Organization's API (v1.4): "
         api_base_url = $stdin.gets.chomp.to_s
 
         client = Kenna::Toolkit::Whitesource::Client.new(api_base_url, @user_key, @request_type, @request_token, @alert_type, @days_back)

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -72,8 +72,7 @@ module Kenna
         initialize_options
 
         puts "Introduce the API Base URL (v1.4) of your Mend Organization:"
-        api_base_url = STDIN.gets.chomp
-        puts "Working on the task with API Base URL: " + api_base_url
+        api_base_url = $stdin.gets.chomp.to_s
 
         client = Kenna::Toolkit::Whitesource::Client.new(api_base_url, @user_key, @request_type, @request_token, @alert_type, @days_back)
 

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -71,7 +71,11 @@ module Kenna
 
         initialize_options
 
-        client = Kenna::Toolkit::Whitesource::Client.new(@user_key, @request_type, @request_token, @alert_type, @days_back)
+        puts "Introduce the API Base URL (v1.4) of your Mend Organization:"
+        api_base_url = STDIN.gets.chomp
+        puts "Working on the task with API Base URL: " + api_base_url
+
+        client = Kenna::Toolkit::Whitesource::Client.new(api_base_url, @user_key, @request_type, @request_token, @alert_type, @days_back)
 
         alerts = client.alerts
         total_issues = alerts.count

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -62,11 +62,11 @@ module Kenna
               required: false,
               default: "output/whitesource",
               description: "If set, will write a file upon completion. Path is relative to #{$basedir}" },
-              { name: 'whitesource_api_base',
-              type: 'string',
+            { name: "whitesource_api_base",
+              type: "string",
               required: true,
               default: nil,
-              description: 'Whitesource API base URL' }
+              description: "Whitesource API base URL" }
           ]
         }
       end

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -66,7 +66,7 @@ module Kenna
               type: "string",
               required: true,
               default: nil,
-              description: "Whitesource API base URL" }
+              description: "Whitesource environment API v4 base URL without prefix e.g. saas.mend.io" }
           ]
         }
       end

--- a/tasks/connectors/whitesource/whitesource_task.rb
+++ b/tasks/connectors/whitesource/whitesource_task.rb
@@ -61,7 +61,12 @@ module Kenna
               type: "filename",
               required: false,
               default: "output/whitesource",
-              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" }
+              description: "If set, will write a file upon completion. Path is relative to #{$basedir}" },
+              { name: 'whitesource_api_base',
+              type: 'string',
+              required: true,
+              default: nil,
+              description: 'Whitesource API base URL' }
           ]
         }
       end
@@ -71,10 +76,7 @@ module Kenna
 
         initialize_options
 
-        puts "Please enter the Base URL for your Mend Organization's API (v1.4): "
-        api_base_url = $stdin.gets.chomp.to_s
-
-        client = Kenna::Toolkit::Whitesource::Client.new(api_base_url, @user_key, @request_type, @request_token, @alert_type, @days_back)
+        client = Kenna::Toolkit::Whitesource::Client.new(@user_key, @request_type, @request_token, @alert_type, @days_back, @api_base_url)
 
         alerts = client.alerts
         total_issues = alerts.count
@@ -115,6 +117,7 @@ module Kenna
         @kenna_api_key = @options[:kenna_api_key]
         @kenna_connector_id = @options[:kenna_connector_id]
         @output_directory = @options[:output_directory]
+        @api_base_url = @options[:whitesource_api_base]
         @skip_autoclose = false
         @retries = 3
         @kdi_version = 2


### PR DESCRIPTION
### [SUP-1524](https://kennasecurity.atlassian.net/browse/SUP-1524)

### **Problem**
Due to Whitesource transitioning to Mend.io, the API version has been updated from 1.3 to 1.4. In version 1.3, we used the static URL:
https://saas.whitesourcesoftware.com/api/v1.3
However, according to Mend.io's documentation (https://docs.mend.io/bundle/api_sca/page/http_api_v1_3_and_v1_4.html) Version 1.4 has the following format
https://(Environment)/api/v1.4

### **Solution**
We should request that customers provide their unique API_BASE_URL as a parameter during task execution, The API_BASE_URL can be found in the Mend.io Organization settings, as shown in the example image 
![image](https://github.com/KennaSecurity/toolkit/assets/121052811/71535797-3f1e-4c92-9823-042118570667)

### **Test**
After the code modifications, the task executes successfully.
<img width="879" alt="image" src="https://github.com/KennaSecurity/toolkit/assets/121052811/d2d5760e-aa62-4137-9ea0-369a4d76389c">





[SUP-1524]: https://kennasecurity.atlassian.net/browse/SUP-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ