### PR TITLE
Fix for aws_guardduty.rb task

### DIFF
--- a/tasks/connectors/aws_guardduty/aws_guardduty.rb
+++ b/tasks/connectors/aws_guardduty/aws_guardduty.rb
@@ -153,8 +153,8 @@ module Kenna
 
         # write a file with the output
         kdi_output = { skip_autoclose: false, assets: @assets, vuln_defs: @vuln_defs }
-        print_good "Output being written to: #{output_path}"
-        File.open(output_path, "w") { |f| f.puts JSON.pretty_generate(kdi_output) }
+        print_good "Output being written to: #{output_dir}/#{filename}"
+        File.open("#{output_dir}/#{filename}", "w") { |f| f.puts JSON.pretty_generate(kdi_output) }
 
         # actually write it
         write_file output_dir, filename, JSON.pretty_generate(kdi_output)


### PR DESCRIPTION
### [SUP-1541](https://kennasecurity.atlassian.net/browse/SUP-1541)

### **Problem**
A bug was identified in AWS GuardDuty task, output_path variable wasn't declared

### **Solution**
Using #{output_dir}/#{filename} instead

[SUP-1541]: https://kennasecurity.atlassian.net/browse/SUP-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ