### PR TITLE
SUP-1541 Fix for undeclared variable on AWS_guardduty.rb toolkit task

### DIFF
--- a/tasks/connectors/aws_guardduty/aws_guardduty.rb
+++ b/tasks/connectors/aws_guardduty/aws_guardduty.rb
@@ -163,7 +163,7 @@ module Kenna
         ####
         ### Finish by uploading if we're all configured
         ####
-        return unless kenna_connector_id && kenna_api_host && kenna_api_key
+        return unless @options[:kenna_connector_id] && @options[:kenna_api_host] && @options[:kenna_api_key]
 
         print_good "Attempting to upload to Kenna API at #{kenna_api_host}"
         upload_file_to_kenna_connector kenna_connector_id, kenna_api_host, kenna_api_key, "#{output_dir}/#{filename}"

--- a/tasks/connectors/aws_guardduty/aws_guardduty.rb
+++ b/tasks/connectors/aws_guardduty/aws_guardduty.rb
@@ -153,8 +153,8 @@ module Kenna
 
         # write a file with the output
         kdi_output = { skip_autoclose: false, assets: @assets, vuln_defs: @vuln_defs }
-        print_good "Output being written to: #{output_path}"
-        File.open(output_path, "w") { |f| f.puts JSON.pretty_generate(kdi_output) }
+        print_good "Output being written to: #{output_dir}/#{filename}"
+        File.open("#{output_dir}/#{filename}", "w") { |f| f.puts JSON.pretty_generate(kdi_output) }
 
         # actually write it
         write_file output_dir, filename, JSON.pretty_generate(kdi_output)


### PR DESCRIPTION
### [SUP-1541](https://kennasecurity.atlassian.net/browse/SUP-1541)

### **Problem**
Output_path variable wasn't declared and it is generating errors 

### **Solution**
Using "#{output_dir}/#{filename}" instead

[SUP-1541]: https://kennasecurity.atlassian.net/browse/SUP-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ