### PR TITLE
SUP-1569-toolkit error out if findings are empty 

### DIFF
--- a/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
+++ b/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
@@ -20,7 +20,7 @@ module Kenna
           "Authorization" => "Basic #{token}"
         }
 
-        offset = page == 1 ? 1 : ((page -1) * page_size) + 1
+        offset = page == 1 ? 1 : ((page - 1) * page_size) + 1
         print_debug "Fetching Page = #{page}"
         payload = {
           "ServiceRequest": {

--- a/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
+++ b/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
@@ -20,7 +20,7 @@ module Kenna
           "Authorization" => "Basic #{token}"
         }
 
-        offset = page == 1 ? 1 : (page * page_size) + 1
+        offset = page == 1 ? 1 : ((page -1) * page_size) + 1
         print_debug "Fetching Page = #{page}"
         payload = {
           "ServiceRequest": {

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -113,8 +113,10 @@ module Kenna
           findings << findings_response
           findings.each do |findg|
             findg.map do |_, finding|
-              qids = findg["ServiceResponse"]["data"]&.map { |x| x["Finding"]["qid"] }.uniq
+              qids = findg["ServiceResponse"]["data"]&.map { |x| x["Finding"]["qid"] }
+              qids = qids.uniq
               next if qids.nil? || qids.empty?
+
               vulns = qualys_was_get_vuln(qids, token)
               vulns = Array.wrap(JSON.parse(vulns)["KNOWLEDGE_BASE_VULN_LIST_OUTPUT"]["RESPONSE"]["VULN_LIST"]["VULN"]).group_by do |vuln|
                 vuln["QID"]

--- a/tasks/connectors/qualys_was/qualys_was.rb
+++ b/tasks/connectors/qualys_was/qualys_was.rb
@@ -113,7 +113,8 @@ module Kenna
           findings << findings_response
           findings.each do |findg|
             findg.map do |_, finding|
-              qids = findg["ServiceResponse"]["data"].map { |x| x["Finding"]["qid"] }.uniq
+              qids = findg["ServiceResponse"]["data"]&.map { |x| x["Finding"]["qid"] }.uniq
+              next if qids.nil? || qids.empty?
               vulns = qualys_was_get_vuln(qids, token)
               vulns = Array.wrap(JSON.parse(vulns)["KNOWLEDGE_BASE_VULN_LIST_OUTPUT"]["RESPONSE"]["VULN_LIST"]["VULN"]).group_by do |vuln|
                 vuln["QID"]


### PR DESCRIPTION
Currently we don't have the check in place if there's empty qid for a single finding, this will result in error in the toolkit task. 

We should skip creating the finding record if the record is invalid for smoother user experiences. 

