### PR TITLE
SUP-1712-change the way to fetch token

### DIFF
--- a/tasks/connectors/aqua/lib/aqua_helper.rb
+++ b/tasks/connectors/aqua/lib/aqua_helper.rb
@@ -49,7 +49,7 @@ module Kenna
 
           if auth_response.code == 200
             auth_json = JSON.parse(auth_response.body)
-            token = auth_json.dig("data", "token")
+            token = auth_json["token"]
 
             print_error "Login failed: No token received" unless token
           else


### PR DESCRIPTION
Currently we're gettin toekn from response json data -> token.

Per postman response, the token has now been moved to the upper level. Causing the toolkit task fail on token not found
Making this line change to accommodate the data change

The response from postman:

RESPONSE:
{
"token": "REDACTED",
"user": {
"id": "REDACTED",
"name": "Vulnerability Management API",
"first_time": false,
"is_super": false,
"ui_access": false,
"actions": {},
"scopes": [
"Global"
],
"last_login": 0,
"last_login_formatted": "",
"role": "API View Only Role",
"roles": [
"API View Only Role"
],
"type": "Aqua",
"plan": "",
"enabled": true,
"last_notification": {
"Time": "0001-01-01T00:00:00Z",
"Valid": false
},
"password_expiration": {
"Time": "2024-09-04T00:00:00Z",
"Valid": true
},
"password_expired": true,
"show_notification": true
},
"license_type": "Standard",
"license": {
"type": "",
"organization": "",
"account_id": "",
"client_name": "",
"name": "",
"email": "",
"num_agents": 0,
"num_microenforcers": 0,
"num_hostenforcers": 0,
"num_images": 0,
"num_functions": 0,
"num_advanced_functions": 0,
"num_pas": 0,
"num_code_repositories": 0,
"license_issue_date": 0,
"license_exp_date": 0,
"non_prod": false,
"approved": false,
"external_token": "",
"strict": false,
"level": "",
"vpatch": false,
"vpatch_coverage": 0,
"malware_protection": false,
"tier": "",
"agents_running": 0,
"images_scanned": 0,
"num_protected_kube_nodes": 0
}
}

