### PR TITLE
SUP-1730 Change Wiz import type default to ISSUES

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       netrc (~> 0.8)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.3.8)
+    rexml (3.3.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/tasks/connectors/wiz/readme.md
+++ b/tasks/connectors/wiz/readme.md
@@ -35,7 +35,7 @@ Complete list of Options:
 | vuln_object_types | false | Array of object types for VULNS import. Allowed values: VIRTUAL_MACHINE,CONTAINER_IMAGE,SERVERLESS. Import all if not present. | n/a |
 | severity | false | Array of severity types for VULNS and ISSUES (ALL) import. Allowed values: CRITICAL,HIGH,MEDIUM,LOW,INFO. Import all if not present. | n/a |
 | issue_status | false | Array of issue status for ISSUES import. Allowed values: OPEN,IN_PROGRESS,RESOLVED,REJECTED. Import all if not present. | n/a |
-| import_type | false | What to import, ISSUES, VULNS or ALL | ALL |
+| import_type | false | What to import, ISSUES, VULNS or ALL | ISSUES |
 | issues_external_id_attr | false | For ISSUES, the entitySnapshot attribute used to map Kenna asset's external_id, for instance, `providerId` or `resourceGroupExternalId`. If not present or the value for the passed attribute is not present the provideId attribute value is used. | n/a |
 | vulns_external_id_attr | false | For VULNS, the `vulnerableEntity` attribute used to map Kenna asset's external_id, for instance, `id`, `providerUniqueId` or `name`. If not present or the value for the passed attribute is not present the `id` attribute value is used. | n/a |
 | issues_hostname_attr | false | For ISSUES, the entitySnapshot attribute used to map Kenna asset's hostname, for instance, `name`, `subscriptionId`, `subscriptionExternalId`, `subscriptionName`, `resourceGroupId`, `resourceGroupExternalId`, `providerId`. If not present or the value for the passed attribute is not present the `name` attribute value is used. | n/a |

--- a/tasks/connectors/wiz/wiz_task.rb
+++ b/tasks/connectors/wiz/wiz_task.rb
@@ -65,7 +65,7 @@ module Kenna
             { name: "import_type",
               type: "string",
               required: false,
-              default: "ALL",
+              default: "ISSUES",
               description: "What to import, ISSUES, VULNS or ALL" },
             { name: "issues_external_id_attr",
               type: "string",


### PR DESCRIPTION
Change Wiz import_type default to ISSUES

## SUP-1730

As per Wiz, Issues contain complete data that needs to be imported, while a Vulnerabilities import might be incomplete and will contain duplicate information if both are done at the same time. Additionally, some Wiz users do not have permissions to retrieve vulnerabilities which is causing the task to fail when default parameters are used. Therefore, we're changing the default import type to ISSUES to avoid conflicting data and so that users don't have to change it manually to run the task.