### PR TITLE
 Require code coverage improvement for pull requests

### DIFF
--- a/.github/workflows/nativeruby.yml
+++ b/.github/workflows/nativeruby.yml
@@ -20,4 +20,8 @@ jobs:
         run: ruby toolkit.rb task=help
       - name: Run tests
         run: bundle exec rspec --format RSpec::Github::Formatter --format documentation
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 output/*
 .idea
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -30,11 +30,13 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec"
   gem "rubocop", require: false
+  gem 'simplecov'
+  gem 'simplecov-cobertura'
   gem "solargraph", require: false
-  gem 'yard', '>= 0.9.36'
   gem "timecop"
   gem "vcr", "~> 6.1"
   gem "webmock", "~> 3.18"
+  gem 'yard', '>= 0.9.36'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       rexml
     crass (1.0.6)
     diff-lcs (1.5.0)
+    docile (1.4.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     e2mmap (0.1.0)
@@ -125,6 +126,15 @@ GEM
     sanitize (6.0.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     solargraph (0.48.0)
       backport (~> 1.2)
       benchmark
@@ -191,6 +201,8 @@ DEPENDENCIES
   rubocop
   ruby-limiter
   sanitize
+  simplecov
+  simplecov-cobertura
   solargraph
   strscan
   timecop

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Kenna Security.
+Copyright (c) 2025 Cisco Systems, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+![Lint Code Base](https://github.com/KennaSecurity/toolkit/workflows/Lint%20Code%20Base/badge.svg)
+![Tests](https://github.com/KennaSecurity/toolkit/workflows/Native-Ruby-Test/badge.svg)
+[![codecov](https://codecov.io/gh/KennaSecurity/toolkit/graph/badge.svg?token=40PYREIHLV)](https://codecov.io/gh/KennaSecurity/toolkit)
+![Bundler Audit](https://github.com/KennaSecurity/toolkit/workflows/Bundler%20Audit/badge.svg)
+![CodeQL](https://github.com/KennaSecurity/toolkit/workflows/CodeQL/badge.svg)
 
 # ABOUT
 
 The Kenna toolkit is a set of functions for data and api manipulation around the Kenna Security Vulnerability Management platform.  It's organized into 'tasks' - units of functionality that can be called and interacted with from the Docker or Podman command line.
-
 
 # USAGE
 
@@ -136,23 +140,22 @@ If you need to use a proxy with this container the suggested implementation is t
 When you find an error, please create a GitHub issue with a detailed description of the error. Our team will solve it as
 soon as possible. [Instructions for creating an issue.](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue)
 
-Please send all toolkit feature requests to kenna.toolkit.list@cisco.com.
+Please send all toolkit feature requests to <kenna.toolkit.list@cisco.com>.
 
 # Development
 
-You can find connector development documentation in the project [Wiki](https://github.com/KennaSecurity/toolkit/wiki/Toolkit-Documentation). 
+You can find connector development documentation in the project [Wiki](https://github.com/KennaSecurity/toolkit/wiki/Toolkit-Documentation).
 
 ## Pull requests
 
 If you have fixed a bug, enhanced a task, or added a new toolkit task, please share it! To submit a pull request:
 
 1. Fork this repository.
-2. Make your changes in a feature branch. Please include specs!
-3. It will speed things along if the lint checks pass and all your specs are green. You can use [act](https://nektosact.com/installation/index.html) to run the checks locally before submitting.
+2. Make your changes in a feature branch. You must write specs for your change. PRs that reduce code coverage will not be accepted.
+3. The lint checks and all specs must pass. You can use [act](https://nektosact.com/installation/index.html) to run the checks locally before submitting.
 4. [Submit a pull request](https://github.com/KennaSecurity/toolkit/compare) to merge your feature branch into this repository's main branch (not your fork) as illustrated below.
 
 <img width="819" alt="proper fork comparison when creating a PR" src="https://github.com/jgarber/toolkit/assets/8061/c3c5cca7-f8af-427f-a932-6f798d91c7e1">
-
 
 ## QA
 
@@ -171,8 +174,4 @@ Prerequisites: API token generated in UI, version of ruby that is specified in `
 - @jcran (initial implementation, various tasks)
 - @jdoss (container work)
 - @caleb-eckenwiler (Documentation)
-
-## Security Badges
-
-![Lint Code Base](https://github.com/KennaPublicSamples/toolkit/workflows/Lint%20Code%20Base/badge.svg)
-![Bundler Audit](https://github.com/KennaPublicSamples/toolkit/workflows/Bundler%20Audit/badge.svg)
+- @jagarber-cisco (DevOps improvements)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Please send all toolkit feature requests to <kenna.toolkit.list@cisco.com>.
 
 # Development
 
-You can find connector development documentation in the project [Wiki](https://github.com/KennaSecurity/toolkit/wiki/Toolkit-Documentation).
+You can find a [connector development guide](https://github.com/KennaSecurity/toolkit/wiki/Development-Guide) in the project [wiki](https://github.com/KennaSecurity/toolkit/wiki).
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # ABOUT
 
-The Kenna toolkit is a set of functions for data and api manipulation around the Kenna Security Vulnerability Management platform.  It's organized into 'tasks' - units of functionality that can be called and interacted with from the Docker or Podman command line.
+The Kenna toolkit is a set of functions for data and api manipulation around the Cisco Vulnerability Management platform.  It's organized into 'tasks' - units of functionality that can be called and interacted with from the Docker or Podman command line.
 
 # USAGE
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
         threshold: 1% # Allow coverage to decrease by this %
     patch:
       default:
-        target: 90%
+        target: 90% # Require 90% coverage on new code
         threshold: 1% # Fudge factor
 comment:
   require_changes: "coverage_drop OR uncovered_patch"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@ coverage:
     project:
       default:
         target: auto  # auto compares coverage to the previous base commit
-        threshold: 1 # Allow coverage to decrease by this %
+        threshold: 1% # Allow coverage to decrease by this %
 comment:
   require_changes: "coverage_drop OR uncovered_patch"
+codecov:
+  max_report_age: off # Don't know why reports from GitHub Actions are outdated

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,5 @@ coverage:
         threshold: 1% # Fudge factor
 comment:
   require_changes: "coverage_drop OR uncovered_patch"
+ignore:
+  - "lib/helpers.rb"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,3 @@ coverage:
         threshold: 1% # Allow coverage to decrease by this %
 comment:
   require_changes: "coverage_drop OR uncovered_patch"
-codecov:
-  max_report_age: off # Don't know why reports from GitHub Actions are outdated

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,9 @@ coverage:
       default:
         target: auto  # auto compares coverage to the previous base commit
         threshold: 1% # Allow coverage to decrease by this %
+    patch:
+      default:
+        target: 90%
+        threshold: 1% # Fudge factor
 comment:
   require_changes: "coverage_drop OR uncovered_patch"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto  # auto compares coverage to the previous base commit
+        threshold: 1 # Allow coverage to decrease by this %
+comment:
+  require_changes: "coverage_drop OR uncovered_patch"

--- a/codeql-analysis.yml
+++ b/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   analyze:

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -6,7 +6,7 @@ module Kenna
       def print_usage
         puts "[ ]                                                                    "
         puts "[+] ========================================================           "
-        puts "[+]  Welcome to the Kenna Security API & Scripting Toolkit!            "
+        puts "[+]  Welcome to the Cisco Vulnerability Management Toolkit!            "
         puts "[+] ========================================================           "
         puts "[ ]                                                                    "
         puts "[ ] Usage:                                                             "

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -4,6 +4,11 @@ require 'bundler'
 Bundler.setup(:default, :test)
 require 'pry-byebug'
 
+require 'simplecov'
+SimpleCov.start # Must come before application code is loaded
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter # Format for Codecov by Sentry
+
 require_relative "../lib/toolkit"
 
 require "timecop"

--- a/spec/tasks/connectors/snyk_v2/snyk_v2_task_spec.rb
+++ b/spec/tasks/connectors/snyk_v2/snyk_v2_task_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Kenna::Toolkit::SnykV2Task do
       spy_on_accumulators
     end
 
+    after do
+      Timecop.return
+    end
+
     context "vulnerability" do
       let(:import_type) { "vulns" }
 


### PR DESCRIPTION
PRs for new tasks (connectors) inevitably become something we have to maintain, which is quite difficult without unit tests!

- Change the README to not just encourage specs but require them.
- Add Codecov so PRs immediately have their code coverage delta measured.
- Require every pull request to have ≥ 90% code coverage (limited to the changed lines).