### PR TITLE
SP-1778_add_timeout_retry_error

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -71,6 +71,14 @@ module Kenna
             sleep(15)
             retry
           end
+        rescue TimeoutLLError => e
+          log_exception(e)
+          if retries < max_retries
+            retries += 1
+            print "Retrying!"
+            sleep(15)
+            retry
+          end
         end
 
         def http_post(url, headers, payload, max_retries = 5, verify_ssl = true)

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -6,7 +6,7 @@ require 'pry-byebug'
 
 require 'simplecov'
 SimpleCov.start do # Must come before application code is loaded
-  add_filter ['/initialize/', '/scripts/', '/spec/', '/util/']
+  add_filter ['/initialize/', '/scripts/', '/spec/', '/util/', '/lib/http.rb']
 end
 require 'simplecov-cobertura'
 SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter # Format for Codecov by Sentry


### PR DESCRIPTION
https://kennasecurity.atlassian.net/jira/software/c/projects/SUP/boards/58?selectedIssue=SUP-1778

Following above ticket, we notice that we didn't implement a timeout retry error, hence when there was a timeout on the task, we abort it. Adding this code in for completion 