### PR TITLE
SUP-1778-adding-opentimeout-to-retry

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -71,6 +71,14 @@ module Kenna
             sleep(15)
             retry
           end
+        rescue RestClient::Exceptions::OpenTimeout => e
+          log_exception(e)
+          if retries < max_retries
+            retries += 1
+            print "Retrying!"
+            sleep(30)
+            retry
+          end
         rescue Errno::ECONNREFUSED => e
           log_exception(e)
           if retries < max_retries


### PR DESCRIPTION
So I realised that we also didn't have the RestClient::Exceptions::OpenTimeout retry logic in the code, 

so I added in in the meantime 