### PR TITLE
fix the missing filter in payload so toolkit don't error out

### DIFF
--- a/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
+++ b/tasks/connectors/qualys_was/lib/qualys_was_helper.rb
@@ -24,6 +24,7 @@ module Kenna
         print_debug "Fetching Page = #{page}"
         payload = {
           "ServiceRequest": {
+            "filters": {},
             "preferences": {
               "verbose": "true",
               "limitResults": page_size,


### PR DESCRIPTION
In the file qualys_was_helper.rb , we don't have the "filter" in the payload , which will error the qualyswas toolkit task when the qualys_was_score_filter is being passed in ...

fixing it

```
 payload = {
          "ServiceRequest": {
--------MISSING FILTERS HERE -------------
            "preferences": {
              "verbose": "true",
              "limitResults": page_size,
              "startFromOffset": offset
            }
          }
        }

        if score.present?
          payload[:ServiceRequest][:filters]["Criteria"] = {
            "field": "severity",
            "operator": "GREATER",
            "value": score.to_i
          }
        end
```