### PR TITLE
SUP-1778-add-additional-read-time-out 

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -87,6 +87,14 @@ module Kenna
             sleep(15)
             retry
           end
+        rescue RestClient::Exceptions::ReadTimeout => e
+          log_exception(e)
+          if retries < max_retries
+            retries += 1
+            print "Retrying!"
+            sleep(15)
+            retry
+          end
         end
 
         def http_post(url, headers, payload, max_retries = 5, verify_ssl = true)


### PR DESCRIPTION
After all the added retry on various error for veracode toolkit task, we're now seeing more of the below error recently. So we will add this error retry accordingly

```
2025-06-20T05:04:58.916Z | from /opt/app/toolkit/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb:100:in `each'
-- | --
  | 2025-06-20T05:04:58.916Z | from /opt/app/toolkit/tasks/connectors/veracode_asset_vulns/veracode_asset_vulns.rb:100:in `run'
  | 2025-06-20T05:04:58.916Z	from toolkit.rb:62:in `<main>' | from toolkit.rb:62:in `<main>'
  | 2025-06-20T05:04:58.922Z | [ ] (20250620050243) Retrying!
  | 2025-06-20T05:04:58.922Z | [!] (20250620050458) Exception! Timed out reading data from server
```
