### PR TITLE
SUP-1820-fix bitsight headers

### DIFF
--- a/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
+++ b/tasks/connectors/digital_footprint/bitsight/lib/bitsight_helpers.rb
@@ -54,7 +54,7 @@ module Kenna
 
       def my_company
         # First get my company
-        response = http_get("https://#{@bitsight_api_key}:@api.bitsighttech.com/portfolio", {})
+        response = http_get("https://#{@bitsight_api_key}:@api.bitsighttech.com/portfolio", @headers)
         portfolio = JSON.parse(response.body)
         @companies = portfolio["companies"]
         @company_guid = portfolio["my_company"]["guid"]


### PR DESCRIPTION
bitsight toolkit tasks is failing for faraday upgrade because http_get methods needs to have valid headers being passed in. 

def my_company
        # First get my company
        response = http_get("https://#{@bitsight_api_key}:@api.bitsighttech.com/portfolio", {})
        portfolio = JSON.parse(response.body)
        @companies = portfolio["companies"]
        @company_guid = portfolio["my_company"]["guid"]
      end


changed the line 

response = http_get("https://#{@bitsight_api_key}:@api.bitsighttech.com/portfolio", {})

to 

response = http_get("https://#{@bitsight_api_key}:@api.bitsighttech.com/portfolio", @headers)