### PR TITLE
SUP-1778-HMAC-generation-adjustment

### DIFF
--- a/lib/faraday_middlewares/faraday_hmac_middleware.rb
+++ b/lib/faraday_middlewares/faraday_hmac_middleware.rb
@@ -11,7 +11,16 @@ class FaradayHmac < Faraday::Middleware
   def call(env)
     uri = URI.parse(env.url.to_s)
     auth_path = "#{uri.path}?#{uri.query}"
-    env.request_headers['Authorization'] = @client.hmac_auth_options(auth_path)[:Authorization]
+    auth_header = @client.hmac_auth_options(auth_path)[:Authorization]
+    env.request_headers['Authorization'] = auth_header
+    
+    # Log when HMAC is being generated
+    if auth_header&.include?('VERACODE-HMAC-SHA-256')
+      timestamp = auth_header[/ts=(\d+)/, 1]
+      nonce = auth_header[/nonce=([^,]+)/, 1]
+      puts "HMAC MIDDLEWARE: Generated auth for #{env.method.upcase} #{env.url} - ts=#{timestamp}, nonce=#{nonce}"
+    end
+    
     @app.call(env)
   end
 end

--- a/lib/faraday_middlewares/faraday_hmac_middleware.rb
+++ b/lib/faraday_middlewares/faraday_hmac_middleware.rb
@@ -13,14 +13,14 @@ class FaradayHmac < Faraday::Middleware
     auth_path = "#{uri.path}?#{uri.query}"
     auth_header = @client.hmac_auth_options(auth_path)[:Authorization]
     env.request_headers['Authorization'] = auth_header
-    
+
     # Log when HMAC is being generated
     if auth_header&.include?('VERACODE-HMAC-SHA-256')
       timestamp = auth_header[/ts=(\d+)/, 1]
       nonce = auth_header[/nonce=([^,]+)/, 1]
       puts "HMAC MIDDLEWARE: Generated auth for #{env.method.upcase} #{env.url} - ts=#{timestamp}, nonce=#{nonce}"
     end
-    
+
     @app.call(env)
   end
 end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -8,7 +8,7 @@ module Kenna
     module Helpers
       module Http
         RETRY_EXCEPTIONS = Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
-          Faraday::ConnectionFailed, Faraday::ClientError, Net::OpenTimeout, Errno::ECONNREFUSED, EOFError
+          Faraday::ConnectionFailed, Faraday::ClientError, Net::OpenTimeout,Errno::ECONNREFUSED, EOFError
         ]
 
         def connection(verify_ssl = true, max_retries = 5, hmac_client: nil)
@@ -16,10 +16,6 @@ module Kenna
             faraday.request :multipart
             faraday.request :json
             faraday.ssl.verify = verify_ssl
-            if hmac_client
-              require_relative './faraday_middlewares/faraday_hmac_middleware'
-              faraday.use FaradayHmac, hmac_client
-            end
             if @options && @options[:debug] == true
               faraday.response :logger # This logs to STDOUT by default
             end
@@ -34,6 +30,10 @@ module Kenna
               retry_block: method(:log_retry),
               exhausted_retries_block: method(:log_retries_exhausted)
             }
+            if hmac_client
+              require_relative './faraday_middlewares/faraday_hmac_middleware'
+              faraday.use FaradayHmac, hmac_client
+            end
             faraday.response :raise_error
             # Faraday can automatically parse JSON responses if this is enabled. However, we shouldn't use JSON.parse if this is enabled
             # faraday.response :json

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -59,17 +59,6 @@ module Kenna
         def log_retry(retry_count:, exception:, will_retry_in:, env: nil, **_kwargs)
           log_exception(exception)
           puts "Retrying request (attempt #{retry_count + 1}) after #{will_retry_in} seconds..."
-          
-          # Log HMAC header to see if it's being regenerated
-          if env && env.request_headers && env.request_headers['Authorization']
-            auth_header = env.request_headers['Authorization']
-            if auth_header&.include?('VERACODE-HMAC-SHA-256')
-              # Extract timestamp and nonce from the header
-              timestamp = auth_header[/ts=(\d+)/, 1]
-              nonce = auth_header[/nonce=([^,]+)/, 1]
-              puts "RETRY: HMAC timestamp=#{timestamp}, nonce=#{nonce}"
-            end
-          end
         end
 
         def log_retries_exhausted(env:, exception:, _options:, **_kwargs)

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -56,9 +56,20 @@ module Kenna
           connection(verify_ssl, max_retries).run_request(:delete, url, nil, headers)
         end
 
-        def log_retry(retry_count:, exception:, will_retry_in:, **_kwargs)
+        def log_retry(retry_count:, exception:, will_retry_in:, env: nil, **_kwargs)
           log_exception(exception)
           puts "Retrying request (attempt #{retry_count + 1}) after #{will_retry_in} seconds..."
+          
+          # Log HMAC header to see if it's being regenerated
+          if env && env.request_headers && env.request_headers['Authorization']
+            auth_header = env.request_headers['Authorization']
+            if auth_header&.include?('VERACODE-HMAC-SHA-256')
+              # Extract timestamp and nonce from the header
+              timestamp = auth_header[/ts=(\d+)/, 1]
+              nonce = auth_header[/nonce=([^,]+)/, 1]
+              puts "RETRY: HMAC timestamp=#{timestamp}, nonce=#{nonce}"
+            end
+          end
         end
 
         def log_retries_exhausted(env:, exception:, _options:, **_kwargs)

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -8,7 +8,7 @@ module Kenna
     module Helpers
       module Http
         RETRY_EXCEPTIONS = Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
-          Faraday::ConnectionFailed, Faraday::ClientError, Net::OpenTimeout,Errno::ECONNREFUSED, EOFError
+          Faraday::ConnectionFailed, Faraday::ClientError, Net::OpenTimeout, Errno::ECONNREFUSED, EOFError
         ]
 
         def connection(verify_ssl = true, max_retries = 5, hmac_client: nil)

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -56,7 +56,7 @@ module Kenna
           connection(verify_ssl, max_retries).run_request(:delete, url, nil, headers)
         end
 
-        def log_retry(retry_count:, exception:, will_retry_in:, env: nil, **_kwargs)
+        def log_retry(retry_count:, exception:, will_retry_in:, **_kwargs)
           log_exception(exception)
           puts "Retrying request (attempt #{retry_count + 1}) after #{will_retry_in} seconds..."
         end

--- a/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
+++ b/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb
@@ -363,6 +363,9 @@ module Kenna
         def find_missing_kenna_assets(application)
           return print "Warning: not connected to Kenna, cannot find missing assets." unless @kenna_api_host && @kenna_api_key && @kenna_connector_id
 
+          # Ensure @assets is initialized
+          kdi_initialize unless @assets
+
           # encoding help
           # enc_open_paren = "%28"
           # enc_close_paren = "%29"


### PR DESCRIPTION
This PR shall fix 2 things: 

1. Veracode is still complaining we're not regenerating new HMAC. 

It looks like the issue is with the middleware order. The HMAC middleware is placed before the retry middleware in the stack, so when retries happen, they reuse the same authorization header without regenerating it.

Adjusting the sequence to see if it will help... 


2. When there's no findings/vulnerabilities on the assets, sometimes the system will fail with error 

opt/app/toolkit/tasks/connectors/veracode_asset_vulns/lib/veracode_av_client.rb:386:in `block in find_missing_kenna_assets': undefined method `none?' for nil:NilClass (NoMethodError)

              if @assets.none? { |new_assets| new_assets["file"] == a["file"] }
                        ^^^^^^


Reasons can be below:

When @assets IS nil (error occurs):
1. No scan types configured: If veracode_scan_types parameter doesn't include any of "STATIC", "DYNAMIC", "MANUAL", or "SCA". => Which shouldn't happen if properly set up 

2. Scan types configured but no findings returned: If the scan types are included but the Veracode API returns no findings for that application (empty results) => This is the likely scenario 

3. API errors: If the HTTP requests to get findings fail or return nil responses


