### PR TITLE
Security updates: Ruby 3.4, dependency bumps, and CI fixes

### DIFF
--- a/.github/workflows/nativeruby.yml
+++ b/.github/workflows/nativeruby.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
 


### PR DESCRIPTION
## Summary
- Update to Ruby 3.4.9 with tightened gem constraints
- Bundle update all gems to latest compatible versions (fixes CVEs in httparty, nokogiri, rexml, thor)
- Fix directory traversal vulnerability (CWE-22) with path sanitization
- Fix JSON.dump segfault by switching to JSON.generate
- Fix CI: Codecov upload failures no longer block builds, bundler-audit runs natively, actions/checkout bumped to v5

## Test plan
- [x] Added tests for `safe_output_path` and path traversal sanitization
- [x] Added `write_file` coverage
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)