### PR TITLE
ci: don't fail build on codecov upload errors

### DIFF
--- a/.github/workflows/nativeruby.yml
+++ b/.github/workflows/nativeruby.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true # optional (default = false)
 


### PR DESCRIPTION
## Summary
- Change `fail_ci_if_error` from `true` to `false` in the Codecov upload step
- Codecov upload failures (e.g. "Token required because branch is protected" on Dependabot PRs) were blocking CI even though the actual tests pass
- Unblocks #608

## Test plan
- [x] Verified the only change is the `fail_ci_if_error` flag
- [ ] Confirm #608 CI passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)